### PR TITLE
Enable the use of the built in debug info pages from cvars/menu

### DIFF
--- a/src/game/debug.c
+++ b/src/game/debug.c
@@ -50,7 +50,10 @@ s8 sDebugLvSelectCheckFlag = FALSE;
 #define DEBUG_PAGE_MIN DEBUG_PAGE_OBJECTINFO
 #define DEBUG_PAGE_MAX DEBUG_PAGE_ENEMYINFO
 
-s8 sDebugPage = DEBUG_PAGE_MIN;
+// #region [PU] Replace variable with CVar so we have better control from the UI and it can be persisted
+// s8 sDebugPage = DEBUG_PAGE_MIN;
+#define sDebugPage CVarGetInteger("gDeveloper.DebugInfoPage", DEBUG_PAGE_MIN)
+// #endregion
 s8 sNoExtraDebug = FALSE;
 s8 sDebugStringArrPrinted = FALSE;
 s8 sDebugSysCursor = 0;
@@ -135,29 +138,29 @@ void set_text_array_x_y(s32 xOffset, s32 yOffset) {
  * current debug mode as well as the printer array (down to up vs up to down).
  */
 void print_debug_bottom_up(const char *str, s32 number) {
-    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT) {
+    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT || CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) {
         print_text_array_info(gDebugPrintState2, str, number);
     }
 }
 
 void print_debug_top_down_objectinfo(const char *str, s32 number) {
-    if ((gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT) && sDebugPage == DEBUG_PAGE_OBJECTINFO) {
+    if ((gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT || CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) && sDebugPage == DEBUG_PAGE_OBJECTINFO) {
         print_text_array_info(gDebugPrintState1, str, number);
     }
 }
 
 void print_debug_top_down_mapinfo(const char *str, s32 number) {
-    if (sNoExtraDebug) { // how come this is the only instance of the sNoExtraDebug check?
+    if (sNoExtraDebug && !CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) { // how come this is the only instance of the sNoExtraDebug check?
         return;
     }
 
-    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT) {
+    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT || CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) {
         print_text_array_info(gDebugPrintState1, str, number);
     }
 }
 
 void print_debug_top_down_normal(const char *str, s32 number) {
-    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT) {
+    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT || CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) {
         print_text_array_info(gDebugPrintState1, str, number);
     }
 }
@@ -332,20 +335,20 @@ UNUSED static void check_debug_button_seq(void) {
  * control sDebugPage's range. (unused)
  */
 UNUSED static void try_change_debug_page(void) {
-    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT) {
+    if (gDebugInfoFlags & DEBUG_INFO_FLAG_DPRINT || CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) {
         if ((gPlayer1Controller->buttonPressed & L_JPAD)
             && (gPlayer1Controller->buttonDown & (L_TRIG | R_TRIG))) {
-            sDebugPage++;
+            CVarSetInteger("gDeveloper.DebugInfoPage", sDebugPage + 1);
         }
         if ((gPlayer1Controller->buttonPressed & R_JPAD)
             && (gPlayer1Controller->buttonDown & (L_TRIG | R_TRIG))) {
-            sDebugPage--;
+            CVarSetInteger("gDeveloper.DebugInfoPage", sDebugPage - 1);
         }
         if (sDebugPage >= (DEBUG_PAGE_MAX + 1)) {
-            sDebugPage = DEBUG_PAGE_MIN;
+            CVarSetInteger("gDeveloper.DebugInfoPage", DEBUG_PAGE_MIN);
         }
         if (sDebugPage < DEBUG_PAGE_MIN) {
-            sDebugPage = DEBUG_PAGE_MAX;
+            CVarSetInteger("gDeveloper.DebugInfoPage", DEBUG_PAGE_MAX);
         }
     }
 }

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -418,12 +418,27 @@ void DrawCheatsMenu() {
     }
 }
 
+const char* debugInfoPages[6] = {
+        "Object",
+        "Check Surface",
+        "Map",
+        "Stage",
+        "Effect",
+        "Enemy",
+};
+
 void DrawDebugMenu() {
     if (UIWidgets::BeginMenu("Developer")) {
         UIWidgets::CVarCheckbox("Debug mode", "gEnableDebugMode", {
             .tooltip = "Various debug features, including a level selector from the main menu"
         });
 
+        UIWidgets::CVarCheckbox("Draw DebugInfo", "gDeveloper.DrawDebugInfo");
+        if (CVarGetInteger("gDeveloper.DrawDebugInfo", 0)) {
+            UIWidgets::CVarCombobox("DebugInfo mode", "gDeveloper.DebugInfoPage", debugInfoPages, {
+                .defaultIndex = 0,
+            });
+        }
         UIWidgets::Spacer(0);
 
         UIWidgets::WindowButton("Stats", "gStatsEnabled", GameUI::mStatsWindow, {


### PR DESCRIPTION
<img width="226" alt="Screenshot 2023-10-11 at 3 05 04 PM" src="https://github.com/HarbourMasters/Ghostship/assets/7316699/78503c5d-55e8-47a9-afbe-69ac3b61ab33">
<img width="637" alt="Screenshot 2023-10-11 at 3 05 26 PM" src="https://github.com/HarbourMasters/Ghostship/assets/7316699/2459cecc-d7da-402b-b58d-a0eddd0d6949">
