### PR TITLE
Extractassets cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,3 +472,20 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
       )
   endif()
 endif()
+
+include(ExternalProject)
+ExternalProject_Add(Torch
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/Torch
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/Torch
+)
+ExternalProject_Get_Property(Torch install_dir)
+set(TORCH_EXECUTABLE ${install_dir}/src/Torch-build/torch)
+add_custom_target(
+    ExtractAssets
+    DEPENDS Torch
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMAND ${TORCH_EXECUTABLE} otr baserom.us.z64
+    # COMMAND ${TORCH_EXECUTABLE} pack assets sm64.otr
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/smcube.otr" "${CMAKE_BINARY_DIR}/smcube.otr"
+    # COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/sm64.otr" "${CMAKE_BINARY_DIR}/sm64.otr"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ add_custom_target(
     DEPENDS Torch
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMAND ${TORCH_EXECUTABLE} otr baserom.us.z64
-    # COMMAND ${TORCH_EXECUTABLE} pack assets sm64.otr
+    COMMAND ${TORCH_EXECUTABLE} pack assets sm64.otr
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/smcube.otr" "${CMAKE_BINARY_DIR}/smcube.otr"
-    # COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/sm64.otr" "${CMAKE_BINARY_DIR}/sm64.otr"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/sm64.otr" "${CMAKE_BINARY_DIR}/sm64.otr"
 )


### PR DESCRIPTION
* needs https://github.com/HarbourMasters/Torch/pull/129 to not segfault when packing `sm64.otr`

i also need https://github.com/HarbourMasters/Torch/commit/1a5d4aa4375c1442b9527b21c0ea17340c7cea0d to not segfault when generating `smcube.otr` - but i'll hold off on PRing that until we confirm there isn't a better fix