### PR TITLE
CMake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,11 +490,12 @@ endif()
 
 include(ExternalProject)
 ExternalProject_Add(Torch
+	PREFIX Torch
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/Torch
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/Torch
 )
 ExternalProject_Get_Property(Torch install_dir)
-set(TORCH_EXECUTABLE ${install_dir}/src/Torch-build/torch)
+set(TORCH_EXECUTABLE ${install_dir}/src/Torch-build/$<CONFIGURATION>/torch)
 add_custom_target(
     ExtractAssets
     DEPENDS Torch


### PR DESCRIPTION
Add prefix to ExternalProject to make everything go in the Torch directory (no more Torch-prefix).

Add `$<CONFIGURATION>` to TORCH_EXECUTABLE to get the right subdirectory for the build directory. Note, this isn't the desired way of doing it, but it works, and I don't know if the desired way is possible as things stand. This just gets the cmake flow to the point where it actually finishes for new developers.