### PR TITLE
Clear GhostshipGui and context on GameEngine::Destroy()

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -340,6 +340,8 @@ void GameEngine::Create() {
 }
 
 void GameEngine::Destroy() {
+    GhostshipGui::Destroy();
+    Instance->context = nullptr;
     AudioExit();
 #ifdef __SWITCH__
     Ship::Switch::Exit();


### PR DESCRIPTION
Fixes an issue where window position and size would not be saved on close, probably other things