### PR TITLE
Handle Windows Macro Collision in `ortho`

### DIFF
--- a/src/port/interpolation/FrameInterpolation.cpp
+++ b/src/port/interpolation/FrameInterpolation.cpp
@@ -12,7 +12,7 @@
 
 extern "C" {
 extern Mat4* gInterpolationMatrix;
-void guOrtho(Mtx* dest, float left, float right, float bottom, float top, float near, float far, float scale);
+void guOrtho(Mtx* dest, float left, float right, float bottom, float oTop, float oNear, float oFar, float oScale);
 }
 /*
 Frame interpolation.
@@ -118,13 +118,13 @@ union Data {
 
     struct {
         Mtx* m;
-        float left;
-        float right;
-        float bottom;
-        float top;
-        float near;
-        float far;
-        float scale;
+        float oLeft;
+        float oRight;
+        float oBottom;
+        float oTop;
+        float oNear;
+        float oFar;
+        float oScale;
     } ortho;
 
     struct {
@@ -460,23 +460,23 @@ struct InterpolateCtx {
                         case Op::Ortho: {
                             // Only interpolate if the difference is significant to avoid jitter
                             constexpr float THRESHOLD = 2.0f;
-                            if (fabsf(old_op.ortho.left - new_op.ortho.left) < THRESHOLD &&
-                                fabsf(old_op.ortho.right - new_op.ortho.right) < THRESHOLD &&
-                                fabsf(old_op.ortho.bottom - new_op.ortho.bottom) < THRESHOLD &&
-                                fabsf(old_op.ortho.top - new_op.ortho.top) < THRESHOLD &&
-                                fabsf(old_op.ortho.near - new_op.ortho.near) < THRESHOLD &&
-                                fabsf(old_op.ortho.far - new_op.ortho.far) < THRESHOLD &&
-                                fabsf(old_op.ortho.scale - new_op.ortho.scale) < THRESHOLD) {
+                            if (fabsf(old_op.ortho.oLeft - new_op.ortho.oLeft) < THRESHOLD &&
+                                fabsf(old_op.ortho.oRight - new_op.ortho.oRight) < THRESHOLD &&
+                                fabsf(old_op.ortho.oBottom - new_op.ortho.oBottom) < THRESHOLD &&
+                                fabsf(old_op.ortho.oTop - new_op.ortho.oTop) < THRESHOLD &&
+                                fabsf(old_op.ortho.oNear - new_op.ortho.oNear) < THRESHOLD &&
+                                fabsf(old_op.ortho.oFar - new_op.ortho.oFar) < THRESHOLD &&
+                                fabsf(old_op.ortho.oScale - new_op.ortho.oScale) < THRESHOLD) {
                                 break;
                             }
-                            float left = lerp(old_op.ortho.left, new_op.ortho.left);
-                            float right = lerp(old_op.ortho.right, new_op.ortho.right);
-                            float bottom = lerp(old_op.ortho.bottom, new_op.ortho.bottom);
-                            float top = lerp(old_op.ortho.top, new_op.ortho.top);
-                            float near = lerp(old_op.ortho.near, new_op.ortho.near);
-                            float far = lerp(old_op.ortho.far, new_op.ortho.far);
-                            float scale = lerp(old_op.ortho.scale, new_op.ortho.scale);
-                            guOrtho(new_replacement(new_op.ortho.m), left, right, bottom, top, near, far, scale);
+                            float left = lerp(old_op.ortho.oLeft, new_op.ortho.oLeft);
+                            float right = lerp(old_op.ortho.oRight, new_op.ortho.oRight);
+                            float bottom = lerp(old_op.ortho.oBottom, new_op.ortho.oBottom);
+                            float oTop = lerp(old_op.ortho.oTop, new_op.ortho.oTop);
+                            float oNear = lerp(old_op.ortho.oNear, new_op.ortho.oNear);
+                            float oFar = lerp(old_op.ortho.oFar, new_op.ortho.oFar);
+                            float scale = lerp(old_op.ortho.oScale, new_op.ortho.oScale);
+                            guOrtho(new_replacement(new_op.ortho.m), left, right, bottom, oTop, oNear, oFar, scale);
                             break;
                         }
                         case Op::MatrixPosRotXYZ: {
@@ -793,12 +793,12 @@ void FrameInterpolation_RecordMatrixTranslate(Mat4* matrix, Vec3f b) {
     append(Op::MatrixTranslate).matrix_translate = { matrix, *((Vec3fInterp*)b) };
 }
 
-void FrameInterpolation_RecordOrtho(Mtx* m, f32 left, f32 right, f32 bottom, f32 top, f32 near, f32 far,
+void FrameInterpolation_RecordOrtho(Mtx* m, f32 left, f32 right, f32 bottom, f32 oTop, f32 oNear, f32 oFar,
                                     f32 scale) {
     if (!check_if_recording()) {
         return;
     }
-    append(Op::Ortho).ortho = { m, left, right, bottom, top, near, far, scale };
+    append(Op::Ortho).ortho = { m, left, right, bottom, oTop, oNear, oFar, scale };
 }
 
 void FrameInterpolation_RecordMatrixScale(Mat4* matrix, f32 scale) {


### PR DESCRIPTION
Renamed ortho.near and .far to avoid Windows macro collisions. Renamed other members of ortho for consistency.