### PR TITLE
Rename some resource types that conflict from Torch

### DIFF
--- a/src/port/importer/MacroObjectFactory.cpp
+++ b/src/port/importer/MacroObjectFactory.cpp
@@ -10,7 +10,7 @@ SM64::MacroObjectFactoryV0::ReadResource(std::shared_ptr<Ship::File> file,
         return nullptr;
     }
 
-    std::shared_ptr<MacroObject> macro = std::make_shared<MacroObject>(initData);
+    std::shared_ptr<MacroObjectResource> macro = std::make_shared<MacroObjectResource>(initData);
     auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     uint32_t count = reader->ReadUInt32();

--- a/src/port/importer/TrajectoryFactory.cpp
+++ b/src/port/importer/TrajectoryFactory.cpp
@@ -8,7 +8,7 @@ SM64::TrajectoryFactoryV0::ReadResource(std::shared_ptr<Ship::File> file,
         return nullptr;
     }
 
-    std::shared_ptr<Trajectory> trajectory = std::make_shared<Trajectory>(initData);
+    std::shared_ptr<TrajectoryResource> trajectory = std::make_shared<TrajectoryResource>(initData);
     auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     uint32_t count = reader->ReadUInt32();

--- a/src/port/importer/types/MacroObject.cpp
+++ b/src/port/importer/types/MacroObject.cpp
@@ -1,11 +1,11 @@
 #include "MacroObject.h"
 
 namespace SM64 {
-int16_t* MacroObject::GetPointer() {
+int16_t* MacroObjectResource::GetPointer() {
     return mData.data();
 }
 
-size_t MacroObject::GetPointerSize() {
+size_t MacroObjectResource::GetPointerSize() {
     return sizeof(mData.size()) * sizeof(int16_t);
 }
 } // namespace SM64

--- a/src/port/importer/types/MacroObject.h
+++ b/src/port/importer/types/MacroObject.h
@@ -4,11 +4,11 @@
 #include <ship/resource/Resource.h>
 
 namespace SM64 {
-class MacroObject : public Ship::Resource<int16_t> {
+class MacroObjectResource : public Ship::Resource<int16_t> {
   public:
     using Resource::Resource;
 
-    MacroObject() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
+    MacroObjectResource() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     int16_t* GetPointer();
     size_t GetPointerSize();

--- a/src/port/importer/types/Trajectory.cpp
+++ b/src/port/importer/types/Trajectory.cpp
@@ -1,11 +1,11 @@
 #include "Trajectory.h"
 
 namespace SM64 {
-TrajectoryData* Trajectory::GetPointer() {
+TrajectoryData* TrajectoryResource::GetPointer() {
     return mData.data();
 }
 
-size_t Trajectory::GetPointerSize() {
+size_t TrajectoryResource::GetPointerSize() {
     return sizeof(mData.size()) * sizeof(TrajectoryData);
 }
 } // namespace SM64

--- a/src/port/importer/types/Trajectory.h
+++ b/src/port/importer/types/Trajectory.h
@@ -12,11 +12,11 @@ struct TrajectoryData {
 
 namespace SM64 {
 
-class Trajectory : public Ship::Resource<TrajectoryData> {
+class TrajectoryResource : public Ship::Resource<TrajectoryData> {
   public:
     using Resource::Resource;
 
-    Trajectory() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
+    TrajectoryResource() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     TrajectoryData* GetPointer();
     size_t GetPointerSize();


### PR DESCRIPTION
Tried building on **Release** mode for my linux machine and starting the game, but was greeted with missing assets. This tells me something that this doesn't feel right:

<img width="770" height="638" alt="Screenshot_20260118_200017" src="https://github.com/user-attachments/assets/b784c301-c6fa-4efd-abbe-a5184e9d5489" />

Doing some troubleshooting by building on **Debug** mode, then providing the rom file, but then before the game even starts, it crashes upon this point. Opening up the debugger with the crash dump, the stack trace gives us where it was mysteriously crashed:

```
#0  0x000055961b6450ac in std::destroy_at<SM64::Trajectory> (__location=0x5596411dfd80) at /usr/include/c++/15.2.1/bits/stl_construct.h:88
#1  0x000055961ba78d5d in std::allocator_traits<std::allocator<SM64::Trajectory> >::destroy<SM64::Trajectory> (__a=..., __p=0x5596411dfd80) at /usr/include/c++/15.2.1/bits/alloc_traits.h:698
#2  std::__relocate_object_a<SM64::Trajectory, SM64::Trajectory, std::allocator<SM64::Trajectory> > (__dest=0x5596411e0710, __orig=0x5596411dfd80, __alloc=...)
    at /usr/include/c++/15.2.1/bits/stl_uninitialized.h:1289
#3  0x000055961ba78890 in std::__relocate_a_1<SM64::Trajectory*, SM64::Trajectory*, std::allocator<SM64::Trajectory> > (__first=0x5596411dfd80, __last=0x5596411dfd88, __result=0x5596411e0710, 
    __alloc=...) at /usr/include/c++/15.2.1/bits/stl_uninitialized.h:1317
#4  0x000055961ba77fc1 in std::__relocate_a<SM64::Trajectory*, SM64::Trajectory*, std::allocator<SM64::Trajectory> > (__first=0x5596411dfd80, __last=0x5596411dfd88, __result=0x5596411e0710, __alloc=...)
    at /usr/include/c++/15.2.1/bits/stl_uninitialized.h:1359
#5  0x000055961ba77a09 in std::vector<SM64::Trajectory, std::allocator<SM64::Trajectory> >::_S_relocate (__first=0x5596411dfd80, __last=0x5596411dfd88, __result=0x5596411e0710, __alloc=...)
    at /usr/include/c++/15.2.1/bits/stl_vector.h:539
#6  0x000055961ba76e1a in std::vector<SM64::Trajectory, std::allocator<SM64::Trajectory> >::_M_realloc_append<short&, short&, short&, short&> (this=0x7fff65f54e60)
    at /usr/include/c++/15.2.1/bits/vector.tcc:599
#7  0x000055961ba7649d in std::vector<SM64::Trajectory, std::allocator<SM64::Trajectory> >::emplace_back<short&, short&, short&, short&> (this=0x7fff65f54e60)
    at /usr/include/c++/15.2.1/bits/vector.tcc:123
#8  0x000055961ba7589e in SM64::TrajectoryFactory::parse (this=0x559637a80f10, buffer=std::vector of length 8388608, capacity 8388608 = {...}, node=...)
    at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/factories/sm64/TrajectoryFactory.cpp:83
#9  0x000055961b8c9c91 in Companion::ParseNode (this=0x559637a7f830, node=..., name="levels/bitfs/bitfs_seg7_trajectory_070159AC") at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:321
#10 0x000055961b8cfdc9 in Companion::ProcessFile (this=0x559637a7f830, root=...) at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:708
#11 0x000055961b8cb22c in Companion::ParseCurrentFileConfig (this=0x559637a7f830, node=...) at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:390
#12 0x000055961b8cf857 in Companion::ProcessFile (this=0x559637a7f830, root=...) at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:674
#13 0x000055961b8d742c in Companion::Process (this=0x559637a7f830) at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:1310
#14 0x000055961b8c8076 in Companion::Init (this=0x559637a7f830, type=ExportType::Binary) at /home/squirrel/Downloads/forN64/Ghostship/Torch/src/Companion.cpp:226
#15 0x000055961b5d5732 in GameExtractor::GenerateOTR (this=0x559637a7d4e0) at /home/squirrel/Downloads/forN64/Ghostship/src/port/GameExtractor.cpp:197
#16 0x000055961b5a51d2 in GameEngine::GenAssetFile (exitOnFail=true) at /home/squirrel/Downloads/forN64/Ghostship/src/port/Engine.cpp:244
#17 0x000055961b5a261d in GameEngine::GameEngine (this=0x559637a76280) at /home/squirrel/Downloads/forN64/Ghostship/src/port/Engine.cpp:92
#18 0x000055961b5a58d8 in GameEngine::Create () at /home/squirrel/Downloads/forN64/Ghostship/src/port/Engine.cpp:333
#19 0x000055961b5d4059 in main () at /home/squirrel/Downloads/forN64/Ghostship/src/port/Game.cpp:34
```

It tells us that it crashed on `std::destroy_at` which calls the destructor of `SM64::Trajectory`. My first intuition was the naming conflicts that I've encountered and fixed in Starship, and I was definitely right about it! Saw this in the importer code:

<img width="1066" height="252" alt="Screenshot_20260118_200509" src="https://github.com/user-attachments/assets/eca3191f-82af-475e-915f-cef3e53cda0d" />

This simple fix is to adding the suffix to the conflicting names with **Resource** on the importer side. I'll leave their file names unchanged however. It is unknown to me how this happens and why there absolutely was no warning or error logged during build.