### PR TITLE
More Save-Related stuff

### DIFF
--- a/levels/course_defines.h
+++ b/levels/course_defines.h
@@ -17,7 +17,7 @@
 DEFINE_COURSE(      COURSE_NONE,     0x44444440, "Course Hub (Castle Grounds)") // (0)
 DEFINE_COURSE(      COURSE_BOB,      0x00022240, "Bob Omb Battlefield") // (1)
 DEFINE_COURSE(      COURSE_WF,       0x00002040, "Whomp's Fortress") // (2)
-DEFINE_COURSE(      COURSE_JRB,      0x22222240, "Jolly Rodger's Bay") // (3)
+DEFINE_COURSE(      COURSE_JRB,      0x22222240, "Jolly Roger Bay") // (3)
 DEFINE_COURSE(      COURSE_CCM,      0x00220040, "Cool Cool Mountain") // (4)
 DEFINE_COURSE(      COURSE_BBH,      0x22222240, "Big Boo's Haunt") // (5)
 DEFINE_COURSE(      COURSE_HMC,      0x22222240, "Hazy Maze Cave") // (6)

--- a/src/port/data/SaveConversion.h
+++ b/src/port/data/SaveConversion.h
@@ -14,9 +14,9 @@ using json = nlohmann::json;
 #define SAVE_FILE_VERSION 1
 
 static std::string entries[] = {
-    "CG", "BOB", "WF", "JRB", "CCM", "BBH", "HMC", "LLL", "SSL", "DDD", "SL",
+    "BOB", "WF", "JRB", "CCM", "BBH", "HMC", "LLL", "SSL", "DDD", "SL",
     "WDW", "TTM", "THI", "TTC", "RR", "BITDW", "BITFS", "BITS", "PSS", "COTMC",
-    "TOTWC", "VCUTM", "WMOTR", "SA", "CAKE_END"
+    "TOTWC", "VCUTM", "WMOTR", "SA", "CG", "CAKE_END"
 };
 
 template<typename T>

--- a/src/port/ui/SaveEditor.cpp
+++ b/src/port/ui/SaveEditor.cpp
@@ -32,7 +32,37 @@ static char courseNames[][31] = {
 #undef DEFINE_COURSES_END
 #undef DEFINE_BONUS_COURSE
 
+std::unordered_map<int16_t, std::pair<u8, bool>> allowedStarFlags = {
+    { COURSE_BOB,   {0x7F, true } },
+    { COURSE_WF,    {0x7F, true } },
+    { COURSE_JRB,   {0x7F, true } },
+    { COURSE_CCM,   {0x7F, true } },
+    { COURSE_BBH,   {0x7F, false} },
+    { COURSE_HMC,   {0x7F, false} },
+    { COURSE_LLL,   {0x7F, false} },
+    { COURSE_SSL,   {0x7F, true} },
+    { COURSE_DDD,   {0xFF, false} },
+    { COURSE_SL,    {0x7F, true } },
+    { COURSE_WDW,   {0x7F, true } },
+    { COURSE_TTM,   {0x7F, true } },
+    { COURSE_THI,   {0x7F, true } },
+    { COURSE_TTC,   {0x7F, false} },
+    { COURSE_RR,    {0x7F, true } },
+    { COURSE_BITDW, {0x01, false} },
+    { COURSE_BITFS, {0x01, false} },
+    { COURSE_BITS,  {0x01, false} },
+    { COURSE_PSS,   {0x03, false} },
+    { COURSE_COTMC, {0x01, false} },
+    { COURSE_TOTWC, {0x01, false} },
+    { COURSE_VCUTM, {0x01, false} },
+    { COURSE_WMOTR, {0x01, true } },
+    { COURSE_SA,    {0x01, false} },
+    { COURSE_NONE,  {0x1F, false} }
+};
+
 bool shouldPopUpOpen = false;
+bool shouldAllowAllStars = false;
+bool shouldAllowEdit = false;
 RandoCheckId popUpId = RC_UNKNOWN;
 std::map<RandoItemId, const char*> objectMap = {
     { RI_COIN_BLUE, "Blue Coin Icon" },
@@ -171,6 +201,7 @@ void SaveEditorWindow::DrawElement() {
             ImGui::SeparatorText("Rando Save Loaded, use the Rando Tab to make changes");
         }
         ImGui::BeginDisabled(IS_RANDO(gCurrSaveFileNum - 1));
+        if (ImGui::Checkbox("Allow all stars", &shouldAllowAllStars)) {}
         for (int i = 1; i < COURSE_COUNT; i++) {
             ImGui::PushID(i - 1);
             u8 courseStarFlags = save_file_get_star_flags(gCurrSaveFileNum - 1, i - 1);
@@ -182,17 +213,23 @@ void SaveEditorWindow::DrawElement() {
                         std::string labelStr = "##courseStars" + std::to_string(s);
                         const char* label = labelStr.c_str();
                         bool isChecked = courseStarFlags & (1 << s);
-
+                        shouldAllowEdit = (allowedStarFlags.contains(i) && (allowedStarFlags[i].first & (1 << s))) ||
+                                               (shouldAllowAllStars);
+                        ImGui::BeginDisabled(!shouldAllowEdit);
                         UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
                         if (UIWidgets::Checkbox(label, &isChecked)) {
                             ModifyStarFlags(isChecked, i, s, gCurrSaveFileNum - 1);
                         }
                         UIWidgets::PopStyleCheckbox();
-                    } else if (s == 7 && i < COURSE_BONUS_STAGES) {
+                        ImGui::EndDisabled();
+                    } else if (s == 7 && (i < COURSE_BONUS_STAGES || i == COURSE_WMOTR)) {
                         std::string labelStr = "##courseCannon" + std::to_string(s);
                         const char* label = labelStr.c_str();
                         bool isChecked = gSaveBuffer.files[gCurrSaveFileNum - 1][0].courseStars[i] & (1 << 7);
+                        shouldAllowEdit = (allowedStarFlags.contains(i) && (allowedStarFlags[i].second)) ||
+                                       (shouldAllowAllStars);
 
+                        ImGui::BeginDisabled(!shouldAllowEdit);
                         UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
                         if (UIWidgets::Checkbox(label, &isChecked,
                                                 UIWidgets::CheckboxOptions{}.Tooltip("Course Cannon"))) {
@@ -203,6 +240,7 @@ void SaveEditorWindow::DrawElement() {
                             }
                         }
                         UIWidgets::PopStyleCheckbox();
+                        ImGui::EndDisabled();
 
                     } else {
                         if (i < COURSE_BONUS_STAGES) {
@@ -236,11 +274,15 @@ void SaveEditorWindow::DrawElement() {
                 std::string labelStr = "##castleStars" + std::to_string(s);
                 const char* label = labelStr.c_str();
                 bool isChecked = gSaveBuffer.files[gCurrSaveFileNum - 1][0].flags & (1 << (24 + s));
+                shouldAllowEdit = (allowedStarFlags.contains(COURSE_NONE) && (allowedStarFlags[COURSE_NONE].first & (1 << s))) ||
+                                   (shouldAllowAllStars);
+                ImGui::BeginDisabled(!shouldAllowEdit);
                 UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
                 if (UIWidgets::Checkbox(label, &isChecked)) {
                     ModifyStarFlags(isChecked, COURSE_NONE, s, gCurrSaveFileNum - 1);
                 }
                 UIWidgets::PopStyleCheckbox();
+                ImGui::EndDisabled();
 
                 ImGui::TableNextColumn();
             }

--- a/src/port/ui/SaveEditor.cpp
+++ b/src/port/ui/SaveEditor.cpp
@@ -33,31 +33,15 @@ static char courseNames[][31] = {
 #undef DEFINE_BONUS_COURSE
 
 std::unordered_map<int16_t, std::pair<u8, bool>> allowedStarFlags = {
-    { COURSE_BOB,   {0x7F, true } },
-    { COURSE_WF,    {0x7F, true } },
-    { COURSE_JRB,   {0x7F, true } },
-    { COURSE_CCM,   {0x7F, true } },
-    { COURSE_BBH,   {0x7F, false} },
-    { COURSE_HMC,   {0x7F, false} },
-    { COURSE_LLL,   {0x7F, false} },
-    { COURSE_SSL,   {0x7F, true} },
-    { COURSE_DDD,   {0xFF, false} },
-    { COURSE_SL,    {0x7F, true } },
-    { COURSE_WDW,   {0x7F, true } },
-    { COURSE_TTM,   {0x7F, true } },
-    { COURSE_THI,   {0x7F, true } },
-    { COURSE_TTC,   {0x7F, false} },
-    { COURSE_RR,    {0x7F, true } },
-    { COURSE_BITDW, {0x01, false} },
-    { COURSE_BITFS, {0x01, false} },
-    { COURSE_BITS,  {0x01, false} },
-    { COURSE_PSS,   {0x03, false} },
-    { COURSE_COTMC, {0x01, false} },
-    { COURSE_TOTWC, {0x01, false} },
-    { COURSE_VCUTM, {0x01, false} },
-    { COURSE_WMOTR, {0x01, true } },
-    { COURSE_SA,    {0x01, false} },
-    { COURSE_NONE,  {0x1F, false} }
+    { COURSE_BOB, { 0x7F, true } },    { COURSE_WF, { 0x7F, true } },     { COURSE_JRB, { 0x7F, true } },
+    { COURSE_CCM, { 0x7F, true } },    { COURSE_BBH, { 0x7F, false } },   { COURSE_HMC, { 0x7F, false } },
+    { COURSE_LLL, { 0x7F, false } },   { COURSE_SSL, { 0x7F, true } },    { COURSE_DDD, { 0xFF, false } },
+    { COURSE_SL, { 0x7F, true } },     { COURSE_WDW, { 0x7F, true } },    { COURSE_TTM, { 0x7F, true } },
+    { COURSE_THI, { 0x7F, true } },    { COURSE_TTC, { 0x7F, false } },   { COURSE_RR, { 0x7F, true } },
+    { COURSE_BITDW, { 0x01, false } }, { COURSE_BITFS, { 0x01, false } }, { COURSE_BITS, { 0x01, false } },
+    { COURSE_PSS, { 0x03, false } },   { COURSE_COTMC, { 0x01, false } }, { COURSE_TOTWC, { 0x01, false } },
+    { COURSE_VCUTM, { 0x01, false } }, { COURSE_WMOTR, { 0x01, true } },  { COURSE_SA, { 0x01, false } },
+    { COURSE_NONE, { 0x1F, false } }
 };
 
 bool shouldPopUpOpen = false;
@@ -214,7 +198,7 @@ void SaveEditorWindow::DrawElement() {
                         const char* label = labelStr.c_str();
                         bool isChecked = courseStarFlags & (1 << s);
                         shouldAllowEdit = (allowedStarFlags.contains(i) && (allowedStarFlags[i].first & (1 << s))) ||
-                                               (shouldAllowAllStars);
+                                          (shouldAllowAllStars);
                         ImGui::BeginDisabled(!shouldAllowEdit);
                         UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
                         if (UIWidgets::Checkbox(label, &isChecked)) {
@@ -226,8 +210,8 @@ void SaveEditorWindow::DrawElement() {
                         std::string labelStr = "##courseCannon" + std::to_string(s);
                         const char* label = labelStr.c_str();
                         bool isChecked = gSaveBuffer.files[gCurrSaveFileNum - 1][0].courseStars[i] & (1 << 7);
-                        shouldAllowEdit = (allowedStarFlags.contains(i) && (allowedStarFlags[i].second)) ||
-                                       (shouldAllowAllStars);
+                        shouldAllowEdit =
+                            (allowedStarFlags.contains(i) && (allowedStarFlags[i].second)) || (shouldAllowAllStars);
 
                         ImGui::BeginDisabled(!shouldAllowEdit);
                         UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
@@ -274,8 +258,9 @@ void SaveEditorWindow::DrawElement() {
                 std::string labelStr = "##castleStars" + std::to_string(s);
                 const char* label = labelStr.c_str();
                 bool isChecked = gSaveBuffer.files[gCurrSaveFileNum - 1][0].flags & (1 << (24 + s));
-                shouldAllowEdit = (allowedStarFlags.contains(COURSE_NONE) && (allowedStarFlags[COURSE_NONE].first & (1 << s))) ||
-                                   (shouldAllowAllStars);
+                shouldAllowEdit =
+                    (allowedStarFlags.contains(COURSE_NONE) && (allowedStarFlags[COURSE_NONE].first & (1 << s))) ||
+                    (shouldAllowAllStars);
                 ImGui::BeginDisabled(!shouldAllowEdit);
                 UIWidgets::PushStyleCheckbox(WIDGET_COLOR);
                 if (UIWidgets::Checkbox(label, &isChecked)) {


### PR DESCRIPTION
In `SaveConversion.h`. the order for the courses, although correct, does not correctly apply when accounting for course stars. This results in a mismatch between what the player collects in game and how it's represented in the save file.
The following is an example save from `develop` after collecting two stars, five coins in BOB and one star, 25 coins in WF.
Old:
```json
 "courseCoinScores": {
  "BBH": 0,
  "BOB": 25,
  "CCM": 0,
  "CG": 5,
  "DDD": 0,
  "HMC": 0,
  "JRB": 0,
  "LLL": 0,
  "SL": 0,
  "SSL": 0,
  "THI": 0,
  "TTC": 0,
  "TTM": 0,
  "WDW": 0,
  "WF": 0
 },
 "courseStars": {
  "BBH": 0,
  "BITDW": 0,
  "BITFS": 0,
  "BITS": 0,
  "BOB": 4,
  "CCM": 0,
  "CG": 33,
  "COTMC": 0,
  "DDD": 0,
  "HMC": 0,
  "JRB": 0,
  "LLL": 0,
  "PSS": 0,
  "RR": 0,
  "SA": 0,
  "SL": 0,
  "SSL": 0,
  "THI": 0,
  "TOTWC": 0,
  "TTC": 0,
  "TTM": 0,
  "VCUTM": 0,
  "WDW": 0,
  "WF": 0,
  "WMOTR": 0
 }
```
Notice how BOB's coin score is lost, since it tried to write to CG (which doesn't have a course coin score entry).
New:
```json
 "courseCoinScores": {
  "BBH": 0,
  "BOB": 5,
  "CCM": 0,
  "DDD": 0,
  "HMC": 0,
  "JRB": 0,
  "LLL": 0,
  "RR": 0,
  "SL": 0,
  "SSL": 0,
  "THI": 0,
  "TTC": 0,
  "TTM": 0,
  "WDW": 0,
  "WF": 25
 },
 "courseStars": {
  "BBH": 0,
  "BITDW": 0,
  "BITFS": 0,
  "BITS": 0,
  "BOB": 33,
  "CCM": 0,
  "CG": 0,
  "COTMC": 0,
  "DDD": 0,
  "HMC": 0,
  "JRB": 0,
  "LLL": 0,
  "PSS": 0,
  "RR": 0,
  "SA": 0,
  "SL": 0,
  "SSL": 0,
  "THI": 0,
  "TOTWC": 0,
  "TTC": 0,
  "TTM": 0,
  "VCUTM": 0,
  "WDW": 0,
  "WF": 4,
  "WMOTR": 0
 }
```
This does mean that this will be a *breaking* change, and old saves will not be compatible from here on out. (If you want to convert your old saves anyway, just move values from CG to BOB, BOB to WF, WF to JRB, and so on.)

Additionally, the save editor has a few more tweaks:
- Invalid stars/cannons that aren't normally reachable are now locked behind a toggle, This makes it easier to choose the correct boxes for a course.
- WMoTR was supposed to receive a cannon checkbox, so it was added here.