### PR TITLE
Guard Satella behind USE_NETWORKING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,12 @@ endif()
 
 # Set game compilation version
 set(VERSION us)
-set(USE_NETWORKING ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch" OR CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
+    set(USE_NETWORKING_DEFAULT OFF)
+else()
+    set(USE_NETWORKING_DEFAULT ON)
+endif()
+option(USE_NETWORKING "Enable the Satella online relay / networking features" ${USE_NETWORKING_DEFAULT})
 set(SKIP_XCODE_VERSION_CHECK ON)
 
 # Add compile definitions for the target

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -554,7 +554,7 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
 #endif
     std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
     while (true) {
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
         auto satellaPhase = Satella::Client::Instance().GetPhase();
         bool satellaActive = satellaPhase == Satella::Phase::Connecting || satellaPhase == Satella::Phase::FetchingKeys;
 #else
@@ -837,7 +837,7 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
                 continue;
             }
             case GS_COMPILE: {
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
                 threadPool->submit_task([&]() -> void {
                     Satella::Client::Instance().Execute();
                     extractStep = GS_LOAD;
@@ -937,7 +937,7 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
                                        ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
                                            ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
                                            ImGuiWindowFlags_NoSavedSettings)) {
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
                 if (satellaActive) {
                     const char* msg = satellaPhase == Satella::Phase::Connecting ? "Connecting to Satella..."
                                                                                  : "Retrieving public keys...";

--- a/src/port/api/relay.cpp
+++ b/src/port/api/relay.cpp
@@ -1,4 +1,4 @@
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
 #include "relay.h"
 #include "port/net/Relay.h"
 #include "spdlog/spdlog.h"

--- a/src/port/net/Relay.cpp
+++ b/src/port/net/Relay.cpp
@@ -1,4 +1,4 @@
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
 #include "Relay.h"
 #include "SatellaClient.h"
 

--- a/src/port/net/Relay.h
+++ b/src/port/net/Relay.h
@@ -1,5 +1,5 @@
 #pragma once
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
 
 #include <cstdint>
 #include <functional>

--- a/src/port/net/SatellaClient.cpp
+++ b/src/port/net/SatellaClient.cpp
@@ -1,4 +1,4 @@
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
 #include "port/net/SatellaClient.h"
 
 #include "ship/Context.h"

--- a/src/port/net/SatellaClient.h
+++ b/src/port/net/SatellaClient.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifndef __SWITCH__
+#ifdef USE_NETWORKING
 #include <condition_variable>
 #include <cstdint>
 #include <memory>


### PR DESCRIPTION
Networking was hard-gated on `#ifndef __SWITCH__`, so it couldn't be disabled on other platforms. Devices without internet pay repeated connect-timeout stalls at startup. This adds a `USE_NETWORKING` option (default `ON`, `OFF` on Switch/CafeOS) and moves the Satella/relay guards onto it. 

`-DUSE_NETWORKING=OFF` compiles out net/ + api/relay.cpp and drops the ixwebsocket/OpenSSL dependency entirely; scripting is unaffected.