### PR TITLE
Fix use-after-free crash in audio synthesis on level reset (#133)

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2622,7 +2622,11 @@ void play_toads_jingle(void) {
 /**
  * Called from threads: thread5_game_loop
  */
+void GameEngine_LockAudioThread(void);
+void GameEngine_UnlockAudioThread(void);
+
 void sound_reset(u8 presetId) {
+    GameEngine_LockAudioThread();
 #ifndef VERSION_JP
     if (presetId >= 8) {
         presetId = 0;
@@ -2651,6 +2655,7 @@ void sound_reset(u8 presetId) {
     D_80332108 = (D_80332108 & 0xf0) + presetId;
     gSoundMode = D_80332108 >> 4;
     sHasStartedFadeOut = FALSE;
+    GameEngine_UnlockAudioThread();
 }
 
 /**

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1182,6 +1182,14 @@ void GameEngine::EndAudioFrame() {
     }
 }
 
+extern "C" void GameEngine_LockAudioThread() {
+    audio.mutex.lock();
+}
+
+extern "C" void GameEngine_UnlockAudioThread() {
+    audio.mutex.unlock();
+}
+
 void GameEngine::AudioInit() {
     const auto resourceMgr = Ship::Context::GetInstance()->GetResourceManager();
     resourceMgr->LoadResources("sound");


### PR DESCRIPTION
`sound_reset()` runs on the game thread and synchronously calls `audio_reset_session()` (reinitializes the audio heap / note pool) while the audio thread is mid-`synthesis_process_notes -> final_resample -> aResampleImpl`, reading freed sample memory.

Added `GameEngine_LockAudioThread/Unlock` bridges that take the same `audio.mutex` `HandleAudioThread` holds during synthesis, and wrapped `sound_reset()`'s body with them. The reset now waits for any in-flight resample frame, and the next synthesis frame waits for the reset to finish.

`sound_reset` is only ever called from the game thread, so there's no audio-thread re-entrancy / deadlock.

Addresses #133 
