### PR TITLE
Fix Mac builds reporting version 0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -975,7 +975,7 @@ add_custom_target(CreateOSXIcons
     COMMENT "Creating OSX icons ..."
     )
     add_dependencies(${PROJECT_NAME} CreateOSXIcons)
-    configure_file("${CMAKE_SOURCE_DIR}/Info.plist" "${CMAKE_BINARY_DIR}/Info.plist" COPYONLY)
+    configure_file("${CMAKE_SOURCE_DIR}/Info.plist" "${CMAKE_BINARY_DIR}/Info.plist" @ONLY)
 INSTALL(TARGETS ${PROJECT_NAME} DESTINATION ../MacOS COMPONENT Ghostship)
 if(ENABLE_SCRIPTING)
     INSTALL(FILES "$<TARGET_FILE:libtcc>" DESTINATION ../MacOS COMPONENT Ghostship)

--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleExecutable</key>
     <string>Ghostship</string>
     <key>CFBundleGetInfoString</key>
-    <string>0.1.0</string>
+    <string>@PROJECT_VERSION@</string>
     <key>CFBundleIconFile</key>
     <string>Ghostship.icns</string>
     <key>CFBundleIdentifier</key>
@@ -22,11 +22,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>@PROJECT_VERSION@</string>
     <key>CFBundleSignature</key>
     <string>ZMM</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>@PROJECT_VERSION@</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 HarbourMasters.</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The Mac app's Info.plist hardcodes 0.1.0 in CFBundleGetInfoString, CFBundleShortVersionString, and CFBundleVersion, so packaged Mac builds report 0.1.0 regardless of the project version (the current mac nightly's app shows this too). This swaps the hardcoded strings for @PROJECT_VERSION@ placeholders and changes the configure_file call from COPYONLY to @ONLY so CMake substitutes the real version at configure time.

Verified locally on macOS (arm64): built the develop branch with and without this change. With it, the packaged app reports 2.1.0 in Get Info and in the dmg name; without it, 0.1.0.

Fixes #219
