### PR TITLE
Fix the current save being wiped after a Game Over

### DIFF
--- a/src/port/data/Saves.cpp
+++ b/src/port/data/Saves.cpp
@@ -48,6 +48,18 @@ bool ShouldLoadOldSaveFile(void) {
     return fs::exists(Ship::Context::GetPathRelativeToAppDirectory("default.sav"));
 }
 
+// save_file_reload() (the game-over path) restores each save from its in-memory
+// backup slot [1], but this loader only fills slot [0], leaving the backups
+// zeroed. A game over then copies zeros over the live save, which shows as a
+// wiped file until restart and becomes permanent once anything saves. Mirror
+// the loaded data into the backup slots so reload restores what was loaded.
+static void MirrorSavesToBackupSlots(void) {
+    for (int32_t fileIndex = 0; fileIndex < NUM_SAVE_FILES; fileIndex++) {
+        gSaveBuffer.files[fileIndex][1] = gSaveBuffer.files[fileIndex][0];
+    }
+    gSaveBuffer.menuData[1] = gSaveBuffer.menuData[0];
+}
+
 void SaveFileLoadAll(void) {
     auto oldSave = Ship::Context::GetPathRelativeToAppDirectory("default.sav");
     if (fs::exists(oldSave)) {
@@ -56,6 +68,7 @@ void SaveFileLoadAll(void) {
         }
         // Move old save files to backup
         fs::rename(oldSave, Ship::Context::GetPathRelativeToAppDirectory("default.sav.bak"));
+        MirrorSavesToBackupSlots();
         return;
     }
 
@@ -94,6 +107,8 @@ void SaveFileLoadAll(void) {
             file.close();
         }
     }
+
+    MirrorSavesToBackupSlots();
 }
 
 void SaveMainMenuData(void) {


### PR DESCRIPTION
save_file_reload(), which runs on the game-over path, restores each save file from its in-memory backup slot. SaveFileLoadAll only fills the live slot when reading the JSON saves, so the backups stay zeroed, and a game over copies zeros over the loaded save: the file shows as empty until the app restarts, and the wipe becomes permanent once the game saves again. Saving during the session repopulates the backup slot, which is why the bug only hits when a game over happens before any save.

The fix mirrors the loaded saves and menu data into the backup slots after loading.

Verified locally on macOS (arm64) with a test build rigged to start with zero lives so a single death triggers a game over: without the fix, a file with one star showed as empty at the file select after the game over; with the fix, the star survived. The rig is not part of this PR.

Fixes #207
