### PR TITLE
Fix held movement keys opening the macOS accent popup

### DIFF
--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -2,6 +2,9 @@
 
 #include <fast/interpreter.h>
 #include "Engine.h"
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
 #ifdef __EMSCRIPTEN__
 #include <SDL2/SDL.h>
 #include "port/web/WebUtils.h"
@@ -46,6 +49,14 @@ void push_frame() {
 int SDL_main(int argc, char** argv) {
 #else
 int main(int argc, char* argv[]) {
+#endif
+#ifdef __APPLE__
+    // Disable the macOS "press and hold" accent/diacritic popup for this app. SDL keeps a Cocoa text
+    // input context active, so holding a movement key is interpreted as holding a letter key in a text
+    // field, and macOS shows the accent picker instead of repeating it. Per-app equivalent of
+    // `defaults write -app <App> ApplePressAndHoldEnabled -bool false`; key repeat still works.
+    CFPreferencesSetAppValue(CFSTR("ApplePressAndHoldEnabled"), kCFBooleanFalse, kCFPreferencesCurrentApplication);
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
 #ifdef __EMSCRIPTEN__
     WebCache_Mount("/storage");


### PR DESCRIPTION
On macOS, holding a movement key like E can open the system accent/diacritic picker instead of repeating, because SDL keeps a Cocoa text input context active. This sets the per-app ApplePressAndHoldEnabled default to false at startup, the equivalent of running `defaults write -app Ghostship ApplePressAndHoldEnabled -bool false` once. Key repeat still works and nothing outside the app is affected.

Reproduced during extended play on macOS (arm64). Same fix SpaghettiKart merged in HarbourMasters/SpaghettiKart#713.
