### PR TITLE
Fix the packaged macOS app failing to launch when built with Homebrew's sdl2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -990,6 +990,20 @@ install(CODE "
     include(BundleUtilities)
     fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/Ghostship\" \"\" \"${dirs}\")
 ")
+# Homebrew's sdl2 is sdl2-compat, a shim that dlopens the real SDL3 at runtime;
+# fixup_bundle cannot follow a dlopen, so the app aborts at launch with
+# "Failed loading SDL3 library." unless SDL3 sits next to the shim in Frameworks
+# (sdl2-compat checks @loader_path). No-op when building against real SDL2.
+find_program(BREW_EXECUTABLE brew)
+if (BREW_EXECUTABLE)
+    execute_process(COMMAND ${BREW_EXECUTABLE} --prefix sdl3
+                    OUTPUT_VARIABLE SDL3_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET)
+    if (SDL3_PREFIX AND EXISTS "${SDL3_PREFIX}/lib/libSDL3.0.dylib")
+        install(PROGRAMS "${SDL3_PREFIX}/lib/libSDL3.0.dylib"
+                DESTINATION ../Frameworks RENAME libSDL3.dylib COMPONENT Ghostship)
+    endif()
+endif()
 endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY APPIMAGE_DESKTOP_FILE_TERMINAL YES)


### PR DESCRIPTION
Homebrew's sdl2 is sdl2-compat, a shim that dlopens the real SDL3 at runtime. fixup_bundle can't follow a dlopen, so a locally packaged app ships without SDL3 and aborts at launch with "Failed loading SDL3 library." This copies libSDL3 into Contents/Frameworks next to the shim, which finds it via @loader_path, whenever brew's sdl3 is present. No-op when building against real SDL2, like CI's MacPorts setup.

<img src="https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/sdl3-launch-crash.png" width="380">

Verified on macOS (arm64): the cpack dmg aborted at launch without this and launches with it.
