### PR TITLE
Fix blurry menu text on Retina displays

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1070,16 +1070,27 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
 ImFont* GameEngine::CreateFontWithSize(float size, std::string fontPath) {
     auto mImGuiIo = &ImGui::GetIO();
     ImFont* font;
+    // Rasterize the glyph atlas at higher density so menu text stays sharp on HiDPI/Retina
+    // displays. Bake at retinaScale * maxMenuScale so the runtime ImGui Menu Scaling setting
+    // (FontGlobalScale) only ever downsamples the atlas rather than stretching it blurry.
+    float rasterDensity = 1.0f;
+#if defined(__APPLE__)
+    constexpr float kRetinaScale = 2.0f;  // Retina backing scale
+    constexpr float kMaxMenuScale = 2.0f; // keep in sync with imguiScaleOptionToValue's max
+    rasterDensity = kRetinaScale * kMaxMenuScale;
+#endif
     if (fontPath == "") {
         ImFontConfig fontCfg = ImFontConfig();
         fontCfg.OversampleH = fontCfg.OversampleV = 1;
         fontCfg.PixelSnapH = true;
         fontCfg.SizePixels = size;
+        fontCfg.RasterizerDensity = rasterDensity;
         font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
     } else {
         auto initData = std::make_shared<Ship::ResourceInitData>();
         ImFontConfig config;
         config.FontDataOwnedByAtlas = false;
+        config.RasterizerDensity = rasterDensity;
 
         initData->Format = RESOURCE_FORMAT_BINARY;
         initData->Type = static_cast<uint32_t>(RESOURCE_TYPE_FONT);
@@ -1096,6 +1107,7 @@ ImFont* GameEngine::CreateFontWithSize(float size, std::string fontPath) {
     iconsConfig.MergeMode = true;
     iconsConfig.PixelSnapH = true;
     iconsConfig.GlyphMinAdvanceX = iconFontSize;
+    iconsConfig.RasterizerDensity = rasterDensity;
     mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
                                                           &iconsConfig, sIconsRanges);
 


### PR DESCRIPTION
On HiDPI/Retina displays the ImGui glyph atlas is rasterized at logical point size and then stretched up by the framebuffer scale, so all the menu text renders fuzzy. This bakes the atlas at retinaScale times the largest Menu Scaling option via ImFontConfig::RasterizerDensity, so text renders at native pixel density and the runtime Menu Scaling setting only ever downsamples the atlas instead of stretching it. No layout or metrics change, macOS only, no effect on standard-DPI displays beyond a larger atlas. Same approach SpaghettiKart merged in HarbourMasters/SpaghettiKart#714.

**Before**

<img src="https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/retina-before.png" width="340">

**After**

<img src="https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/retina-after.png" width="340">

Verified on macOS (arm64): menu text is crisp at all four Menu Scaling settings with this change, fuzzy without it.
