### PR TITLE
Fix Satella never connecting on macOS

### DIFF
--- a/src/port/net/SatellaClient.cpp
+++ b/src/port/net/SatellaClient.cpp
@@ -172,13 +172,21 @@ void Client::OnMessage(const ix::WebSocketMessagePtr& msg) {
 
 static ix::SocketTLSOptions BuildTLSOptions() {
     ix::SocketTLSOptions opts;
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
+    // ixwebsocket's mbedtls backend has no system certificate store outside
+    // Windows, so point it at the platform's CA bundle file explicitly.
+#if defined(__APPLE__)
+    static constexpr const char* kCAPaths[] = {
+        "/etc/ssl/cert.pem",
+    };
+#else
     static constexpr const char* kCAPaths[] = {
         "/etc/ssl/certs/ca-certificates.crt",
         "/etc/pki/tls/certs/ca-bundle.crt",
         "/etc/ssl/ca-bundle.pem",
         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
     };
+#endif
     for (const char* path : kCAPaths) {
         if (access(path, R_OK) == 0) {
             opts.caFile = path;
@@ -200,7 +208,7 @@ void Client::Connect(const std::string& url) {
 
     mUrl = url;
     mWs.setUrl(url + "/ws?v=" GHOSTSHIP_VERSION);
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
     mWs.setTLSOptions(BuildTLSOptions());
 #endif
     mWs.setOnMessageCallback([this](const ix::WebSocketMessagePtr& msg) { OnMessage(msg); });


### PR DESCRIPTION
Since the switch to the mbedtls TLS backend, macOS builds can't complete the TLS handshake with the Satella relay, so every launch shows the Connecting to Satella screen for the full 10 second timeout and the game then runs without Satella. The log fills with `SatellaClient: WebSocket error: Unable to connect to satella.net64.dev on port 443, error: no error` followed by `SatellaClient: failed to connect`.

The cause is that ixwebsocket's mbedtls backend only implements the system certificate store on Windows, so it needs to be pointed at a CA bundle file on other platforms. #199 fixed this for Linux by probing the usual CA bundle paths, but on macOS setTLSOptions is never called, so the handshake fails with no trusted roots. This change extends the same lookup to macOS using the system bundle at /etc/ssl/cert.pem, which ships with the OS. Certificate and hostname verification stay enabled.

Verification (macOS 26, arm64):
- develop (49c5312a) build: fails after the full 10 second timeout on every launch, with the log lines above.
- with this change: `SatellaClient: connected` and `player registered` about 0.4 seconds after `Waiting for satella...`, and the startup screen is down to the 1 to 2 seconds (or lower) described in #199.
- Release 2.0.0, which predates the mbedtls switch, still connects fine on macOS, so this only affects newer builds.
