### PR TITLE
Fix the title screen background after a Game Over

### DIFF
--- a/src/menu/intro_geo.c
+++ b/src/menu/intro_geo.c
@@ -156,10 +156,21 @@ Gfx *intro_backdrop_one_image(s32 index, s8 *backgroundTable) {
     Mtx *mtx = alloc_display_list(sizeof(*mtx));
     Gfx *displayList = alloc_display_list(36 * sizeof(*displayList));
     Gfx *displayListIter = displayList;
-    const u8 *const *vIntroBgTable = segmented_to_virtual(textureTables[backgroundTable[0]]);
+    s32 col = index % num_tiles_h;
+    s32 row = index / num_tiles_h;
+
+    // Map the on-screen tile back onto the original 4x3 grid so each tile reads
+    // its own table entry; extra widescreen columns reuse the nearest edge tile.
+    s32 logicalCol = (s32)((col * 80 + 40 + xOffset) / 80);
+    if (logicalCol < 0) {
+        logicalCol = 0;
+    } else if (logicalCol > 3) {
+        logicalCol = 3;
+    }
+    const u8 *const *vIntroBgTable = segmented_to_virtual(textureTables[backgroundTable[(2 - row) * 4 + logicalCol]]);
     s32 i;
 
-    guTranslate(mtx, ((index % num_tiles_h) * 80) + xOffset, (index/num_tiles_h) * 80, 0.0f);
+    guTranslate(mtx, (col * 80) + xOffset, row * 80, 0.0f);
     gSPMatrix(displayListIter++, mtx, G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_PUSH);
     gSPDisplayList(displayListIter++, title_screen_bg_dl_0A000118);
     for (i = 0; i < 4; ++i) {
@@ -227,13 +238,15 @@ Gfx *geo_intro_gameover_backdrop(s32 state, struct GraphNode *node, UNUSED void 
     s32 j;
     s32 i;
 
+    s32 num_tiles_h = (s32)((GFX_DIMENSIONS_ASPECT_RATIO * SCREEN_HEIGHT + 80 ) / 80) * 3;
+
     if (state != 1) {  // reset
         sGameOverFrameCounter = 0;
         sGameOverTableIndex = -2;
         for (i = 0; i < ARRAY_COUNT(gameOverBackgroundTable); ++i)
             gameOverBackgroundTable[i] = INTRO_BACKGROUND_GAME_OVER;
     } else {  // draw
-        dl = alloc_display_list(16 * sizeof(*dl));
+        dl = alloc_display_list((num_tiles_h + 4) * sizeof(*dl));
         dlIter = dl;
         if (sGameOverTableIndex == -2) {
             if (sGameOverFrameCounter == 180) {
@@ -259,7 +272,7 @@ Gfx *geo_intro_gameover_backdrop(s32 state, struct GraphNode *node, UNUSED void 
         // draw all the tiles
         gSPDisplayList(dlIter++, dl_proj_mtx_fullscreen);
         gSPDisplayList(dlIter++, title_screen_bg_dl_0A000100);
-        for (j = 0; j < ARRAY_COUNT(gameOverBackgroundTable); ++j)
+        for (j = 0; j < num_tiles_h; ++j)
             gSPDisplayList(dlIter++, intro_backdrop_one_image(j, gameOverBackgroundTable));
         gSPDisplayList(dlIter++, title_screen_bg_dl_0A000190);
         gSPEndDisplayList(dlIter);


### PR DESCRIPTION
Fixes #205.

After a Game Over, the title screen background misrenders in two ways: parts of the tile wall are missing (black rectangles), and once the transition starts every tile flips from GAME OVER to SUPER MARIO 64 in the same frame instead of one at a time.

Both come from the widescreen backdrop rework (e0182f49), which left a TODO on the Game Over path:
- `intro_backdrop_one_image` reads `backgroundTable[0]` for every tile, so all tiles show whichever image tile 0 currently has. The moment the flip animation changes tile 0, the whole wall changes with it.
- `geo_intro_gameover_backdrop` still draws only the original 12 tiles, but the positioning helper lays tiles out in the wider aspect-based grid, so the top row is left mostly undrawn.

This change maps each on-screen tile back onto the original 4x3 grid so every tile reads its own table entry (columns match exactly at 4:3, and extra widescreen columns reuse the nearest edge tile), and sizes the Game Over backdrop from the aspect ratio the same way `geo_intro_regular_backdrop` already does. The flip order and timing are untouched, so the transition sweeps around the screen like the original game.

Before:

![before](https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/gameover-before.png)

After:

![after](https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/gameover-after.png)

Verification (macOS 26, arm64): A/B against develop 49c5312a using a test rig that starts with zero lives so one death triggers a Game Over (the rig was identical on both sides and is not part of this PR). Stock reproduces both symptoms; with this change the tile wall covers the whole screen and the tiles flip one at a time, matching the original hardware video in #205.
