### PR TITLE
Fix achievements tracking and popping while the toggle is off

### DIFF
--- a/src/port/api/achievements.cpp
+++ b/src/port/api/achievements.cpp
@@ -25,7 +25,7 @@ extern "C" void C_RegisterAchievement(const char* id, const C_AchievementDef* de
 }
 
 extern "C" void C_AchievementProgress(const char* id, int32_t amount) {
-    if (!id) {
+    if (!id || !Achievement_SystemActive()) {
         return;
     }
     Achievement_Progress(id, amount);

--- a/src/port/mods/achievements/Achievements.cpp
+++ b/src/port/mods/achievements/Achievements.cpp
@@ -238,6 +238,12 @@ void Achievement_LoadTexture(const std::string& id) {
         ->LoadTextureFromResource(std::string(achievement.icon) + ".locked", texture);
 }
 
+// A file's achievements flag marks it as participating in the achievement
+// system; the menu toggle must also be on for anything to track or pop.
+bool Achievement_SystemActive() {
+    return HAS_ACHIEVEMENTS(selectedFile) && CVarGetInteger(CVAR_ENHANCEMENT("Achievements"), 1) == 1;
+}
+
 void Achievements_Load(IEvent* event) {
     const OnGameFileLoad* ev = reinterpret_cast<OnGameFileLoad*>(event);
     selectedFile = ev->fileNum - 1;
@@ -302,7 +308,7 @@ void Achievements_Init() {
     REGISTER_LISTENER(OnGameFileSave, EVENT_PRIORITY_NORMAL, Achievements_Save);
 
     REGISTER_LISTENER(ItemCollected, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -430,7 +436,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(CapSwitchActivated, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -452,7 +458,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(BossDefeated, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -493,7 +499,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(GameFrameUpdate, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -523,7 +529,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(MusicChanged, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -539,7 +545,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(BossBattleStarted, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -549,7 +555,7 @@ void Achievements_Init() {
 
     //! This isn't triggering for koopa fights, since the music doesn't mute
     REGISTER_LISTENER(BossBattleEnded, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -560,7 +566,7 @@ void Achievements_Init() {
     REGISTER_LISTENER(PlayerDeath, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         const PlayerDeath* ev = reinterpret_cast<PlayerDeath*>(event);
 
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -607,7 +613,7 @@ void Achievements_Init() {
     REGISTER_LISTENER(PlayerSetAction, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
         const PlayerSetAction* ev = reinterpret_cast<PlayerSetAction*>(event);
 
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -635,7 +641,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(ChainChompRelease, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 
@@ -643,7 +649,7 @@ void Achievements_Init() {
     });
 
     REGISTER_LISTENER(GameEnded, EVENT_PRIORITY_NORMAL, [](IEvent* event) {
-        if (!HAS_ACHIEVEMENTS(selectedFile)) {
+        if (!Achievement_SystemActive()) {
             return;
         }
 

--- a/src/port/mods/achievements/Achievements.h
+++ b/src/port/mods/achievements/Achievements.h
@@ -48,5 +48,6 @@ extern std::unordered_map<std::string, Achievement>         gAchievementList;
 extern std::unordered_map<std::string, AchievementProgress> gAchievementProgress;
 
 extern AchievementProgress* Achievement_GetProgress(const std::string& id);
+extern bool Achievement_SystemActive();
 extern void                 Achievement_Progress(const std::string& id, int32_t amount = 1);
 #endif


### PR DESCRIPTION
Fixes #209.

The Enable Achievements checkbox is only consulted when a save file is first loaded, and only for files that don't yet have the achievements feature flag. All the runtime listeners gate on the per-file flag alone, so on a file that already has achievements the toggle changes nothing: progress keeps tracking and completed achievements keep popping notifications. This also explains the reporter's observation that files created fresh with the toggle off behave correctly, since those never get the flag.

This change adds an `Achievement_SystemActive()` helper that requires the file flag and the toggle together, and gates the runtime listeners and the mod API on it. Loading and saving still use the per-file flag alone, so stored progress is preserved and written back unchanged while the toggle is off, and turning the toggle back on resumes tracking from the stored values instead of wiping anything.

Verification (macOS 26, arm64): A/B against develop 49c5312a on a save file with the achievements flag set and the toggle off, using a test rig that maps a key press to the game's normal death path (the rig was identical on both sides and is not part of this PR). Stock pops the Die by an Enemy achievement on death with the toggle off; with this change nothing tracks or pops while the toggle is off, and turning the toggle back on mid session resumes tracking with the previous progress intact.
