### PR TITLE
Fix the Bowser key being treated like a star with Collecting Stars Will Not Exit Level enabled

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -779,7 +779,11 @@ u32 interact_water_ring(struct MarioState *m, UNUSED u32 interactType, struct Ob
 u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct Object *o) {
     u32 starIndex;
     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
-    u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0 || CVarGetInteger("gEnhancements.StarNoExit", 0);
+    // The Bowser fights award their key through this same interaction; the
+    // StarNoExit enhancement is meant for stars, so keys keep their normal exit.
+    u32 isBowserKey = gCurrLevelNum == LEVEL_BOWSER_1 || gCurrLevelNum == LEVEL_BOWSER_2;
+    u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0 ||
+                 (!isBowserKey && CVarGetInteger("gEnhancements.StarNoExit", 0));
     u32 grandStar = (o->oInteractionSubtype & INT_SUBTYPE_GRAND_STAR) != 0;
 
     if (m->health >= 0x100) {


### PR DESCRIPTION
Fixes #170.

The Bowser fights award their key through the same interaction that handles stars, so with the Collecting Stars Will Not Exit Level enhancement on, grabbing the key played the star jingle, showed the save dialog, and left Mario standing in the fight instead of the normal key collection and exit.

This change skips the enhancement in the two key-awarding Bowser levels, matching the key check act_star_dance already uses. Stars everywhere else keep the enhancement's behavior.

Before:

![before](https://raw.githubusercontent.com/quarrel07/Ghostship-macOS/assets/pr-assets/bowser-key-star-dialog.png)

Verification (macOS 26, arm64): A/B against develop with only this change differing, using a test rig that spawns the key in the Bowser 1 arena (the rig is not part of this PR). Stock reproduces the star jingle, save dialog, and no exit; with this change the key collects normally and the exit sequence plays.
