### PR TITLE
Fix the crash on quit

### DIFF
--- a/src/port/ui/GhostshipGui.cpp
+++ b/src/port/ui/GhostshipGui.cpp
@@ -185,6 +185,9 @@ void Destroy() {
     mShaderSettingsWindow = nullptr;
 #endif
     mGfxDebuggerWindow = nullptr;
+    mTouchControlsOverlay = nullptr;
+    mAchievementsWindow = nullptr;
+    mEventDebuggerWindow = nullptr;
 }
 
 void RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,


### PR DESCRIPTION
Quitting current develop aborts the process every time. The crash report ends in `Ship::Component::~Component()` called from `~shared_ptr<Ship::EventDebuggerWindow>` during `__cxa_finalize`, that is, static destruction at process exit.

GhostshipGui keeps its windows in file-scope shared_ptr globals and Destroy() releases them while the engine is still alive, but three were missed: mTouchControlsOverlay, mAchievementsWindow, and mEventDebuggerWindow. Those were destroyed after main returned, once the logger was already gone, and the component destructor's logging threw out of a noexcept destructor.

This change releases the remaining three in Destroy() alongside the others.

Verification (macOS 26, arm64, develop 5fda461a): stock crashes on every quit with the stack above; with this change the game exits cleanly.
