### PR TITLE
Fix the game rendering only a black screen on current develop

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1619,7 +1619,7 @@ uint8_t GameEngine::GetBankIdByName(const std::string& name) {
 }
 
 uint32_t GameEngine::GetGameVersion() {
-    return BSWAP32(ShipCompat::GetResourceManager()->GetArchiveManager()->GetGameVersions()[0]);
+    return ShipCompat::GetResourceManager()->GetArchiveManager()->GetGameVersions()[0];
 }
 
 void GameEngine::RunCommands(Gfx* Commands, const std::vector<FrameInterpolationResult>& replacements) {


### PR DESCRIPTION
On current develop the game view stays black after launch (the Ghostship ImGui menu and audio still work), and the log shows `Function table does not contain address ... on NODE_ASM` for every geometry callback the title screen uses.

The archive's version file declares its own endianness and the archive reader honors it, so GetGameVersions() already returns the ROM CRC in host order (0xFF2B5A63 for US). Since 70b35692 GameEngine::GetGameVersion() byte-swaps that value again, which turns it into a key no function table has, so every NODE_ASM lookup fails and no geometry is drawn. The C accessor GameEngine_GetGameVersion() that ROM_JP uses never swapped, so the two accessors also disagreed. Torch's ROM_CRC_BSWAP option is off in this build, so archives written by the current Torch carry the same bytes as older ones; this affects every sm64.o2r, not only older ones.

This change returns the value as read, matching the C accessor.

Verification (macOS 26, arm64, develop 5fda461a with an existing sm64.o2r): stock shows the black screen with the four NODE_ASM errors; with this change the title screen renders normally.
