### PR TITLE
CI: cut macOS build time from ~86 min to ~15 min by caching MacPorts

### DIFF
--- a/.github/macports.yml
+++ b/.github/macports.yml
@@ -1,0 +1,33 @@
+ports:
+  - name: libsdl2
+    select: [ universal ]
+  - name: libsdl2_net
+    select: [ universal ]
+  - name: libpng
+    select: [ universal ]
+  - name: glew
+    select: [ universal ]
+  - name: libzip
+    select: [ universal ]
+  - name: nlohmann-json
+    select: [ universal ]
+  - name: tinyxml2
+    select: [ universal ]
+  - name: libogg
+    select: [ universal ]
+  - name: libopus
+    select: [ universal ]
+  - name: opusfile
+    select: [ universal ]
+  - name: libvorbis
+    select: [ universal ]
+  - name: mbedtls
+    select: [ universal ]
+  - name: vulkan-headers
+    select: [ universal ]
+  - name: vulkan-loader
+    select: [ universal ]
+  - name: MoltenVK
+    select: [ universal ]
+  - name: shaderc
+    select: [ universal ]

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,6 +9,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # full history so the libultraship submodule gitlink resolves
+      - name: Setup MacPorts
+        uses: melusina-org/setup-macports@v1
+        with:
+          parameters: '.github/macports.yml'
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -18,37 +22,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-14-ccache-${{ github.ref }}
             ${{ runner.os }}-14-ccache
-      # Needed to apply sudo for macports cache restore
-      # - name: Install gtar wrapper
-      #   run: |
-      #     sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
-      #     sudo cp .github/workflows/gtar /opt/homebrew/bin/gtar
-      #     sudo chmod +x /opt/homebrew/bin/gtar
-      - name: Restore Cached MacPorts
-        id: restore-cache-macports
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ runner.os }}-14-macports-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-14-macports-${{ github.ref }}
-            ${{ runner.os }}-14-macports-
-          path: /opt/local/
-      - name: Install MacPorts (if necessary)
-        run: |
-          if command -v /opt/local/bin/port 2>&1 >/dev/null; then
-            echo "MacPorts already installed"
-          else
-            echo "Installing MacPorts"
-            wget https://github.com/macports/macports-base/releases/download/v2.11.5/MacPorts-2.11.5-14-Sonoma.pkg
-            sudo installer -pkg ./MacPorts-2.11.5-14-Sonoma.pkg -target /
-          fi
-          echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
       - name: Install Python dependencies
         run: python3 -m pip install -r libultraship/requirements.txt --break-system-packages || python3 -m pip install -r libultraship/requirements.txt
       - name: Install dependencies
         run: |
           brew uninstall --ignore-dependencies libpng
-          sudo port install libsdl2 +universal libsdl2_net +universal libpng +universal glew +universal libzip +universal nlohmann-json +universal tinyxml2 +universal libogg +universal libopus +universal opusfile +universal libvorbis +universal mbedtls +universal vulkan-headers +universal vulkan-loader +universal MoltenVK +universal shaderc +universal
           brew install ninja
       - name: Build (Universal)
         run: |
@@ -68,9 +46,3 @@ jobs:
             name: ghostship-mac-universal
             path: ghostship-release
             retention-days: 1
-      - name: Save Cache MacPorts
-        if: ${{ github.ref_name == github.event.repository.default_branch }}
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ steps.restore-cache-macports.outputs.cache-primary-key }}
-          path: /opt/local/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,6 +173,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # full history so the libultraship submodule gitlink resolves
+      - name: Setup MacPorts
+        uses: melusina-org/setup-macports@v1
+        with:
+          parameters: '.github/macports.yml'
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -182,37 +186,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-14-ccache-${{ github.ref }}
             ${{ runner.os }}-14-ccache
-      # Needed to apply sudo for macports cache restore
-      # - name: Install gtar wrapper
-      #   run: |
-      #     sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
-      #     sudo cp .github/workflows/gtar /opt/homebrew/bin/gtar
-      #     sudo chmod +x /opt/homebrew/bin/gtar
-      - name: Restore Cached MacPorts
-        id: restore-cache-macports
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ runner.os }}-14-macports-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-14-macports-${{ github.ref }}
-            ${{ runner.os }}-14-macports-
-          path: /opt/local/
-      - name: Install MacPorts (if necessary)
-        run: |
-          if command -v /opt/local/bin/port 2>&1 >/dev/null; then
-            echo "MacPorts already installed"
-          else
-            echo "Installing MacPorts"
-            wget https://github.com/macports/macports-base/releases/download/v2.11.5/MacPorts-2.11.5-14-Sonoma.pkg
-            sudo installer -pkg ./MacPorts-2.11.5-14-Sonoma.pkg -target /
-          fi
-          echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
       - name: Install Python dependencies
         run: python3 -m pip install -r libultraship/requirements.txt --break-system-packages || python3 -m pip install -r libultraship/requirements.txt
       - name: Install dependencies
         run: |
           brew uninstall --ignore-dependencies libpng
-          sudo port install libsdl2 +universal libsdl2_net +universal libpng +universal glew +universal libzip +universal nlohmann-json +universal tinyxml2 +universal libogg +universal libopus +universal opusfile +universal libvorbis +universal mbedtls +universal vulkan-headers +universal vulkan-loader +universal MoltenVK +universal shaderc +universal
           brew install ninja
       - name: Build (Universal)
         run: |
@@ -243,12 +221,6 @@ jobs:
             .tcc
             Ghostship.dmg
             readme.txt
-      - name: Save Cache MacPorts
-        if: ${{ github.ref_name == github.event.repository.default_branch }}
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ steps.restore-cache-macports.outputs.cache-primary-key }}
-          path: /opt/local/
 
   build-ios:
     needs: generate-port-o2r


### PR DESCRIPTION
Switches the macOS jobs to melusina-org/setup-macports with a parameters file listing the same 16 ports with the universal variant, the way Shipwright's generate-builds.yml does. The action installs MacPorts, installs the ports, and caches the prefix itself, keyed on the macOS version and the parameters file, so the cache stays stable across commits.

**[0cedd950](https://github.com/quarrel07/Ghostship/commit/0cedd950) CI: cache MacPorts on the macOS runners via setup-macports**

The current restore step runs before MacPorts exists on the runner, and the runner user cannot create /opt/local, so the cached prefix does not unpack and the universal ports get built from source on each run. On develop that install step is about 78 minutes of the 86 minute job (run 33546991018), most of it spirv-tools, cmake, and two Python versions. With the action handling the prefix, that work happens once and is reused. The restore, manual install, and save steps are replaced; the ccache step, the libpng uninstall, ninja, the Python requirements, and the VULKAN_SDK export are unchanged. Applied to both main.yml and mac.yml.

**Verification**

Two GenerateBuilds runs on my fork with this branch. First run, empty cache (33996612448): Setup MacPorts 77.4 min, the one-time compile that fills the cache; build-macos green end to end. Second run, filled cache (34001356850): Setup MacPorts 0.5 min, whole job 14.5 min. The Build step is 13 to 19 min in both because the fork has no ccache; on develop it is about 4 min, so the job there should come in around 5 to 6 minutes, in line with Shipwright's build-macos on the same runner class.