### PR TITLE
Keep existing sm64.o2r archives working after the Torch CRC byte-order change

### DIFF
--- a/include/sm64.h
+++ b/include/sm64.h
@@ -23,7 +23,10 @@
 #include "align_asset_macro.h"
 
 #define GAME_VERSION GameEngine_GetGameVersion()
-#define ROM_JP (GAME_VERSION == 0xE3DAA4E)
+// ROM CRCs of the supported versions, as returned by GAME_VERSION.
+#define GAME_VERSION_US 0xFF2B5A63
+#define GAME_VERSION_JP 0x0E3DAA4E
+#define ROM_JP (GAME_VERSION == GAME_VERSION_JP)
 
 #if defined(_WIN32) || defined(__SWITCH__) || defined(__ANDROID__)
 #define bzero(b,len) (memset((b), '\0', (len)), (void) 0)

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -171,6 +171,26 @@ bool VerifyArchiveVersion(OTRVersion version) {
     return version.major == gBuildVersionMajor && version.minor == gBuildVersionMinor;
 }
 
+// True when the archive's "version" file holds a ROM CRC we do not recognize in either byte
+// order. A missing or unreadable file is not treated as unknown, so only a real mismatch
+// sends the user back through extraction.
+static bool IsArchiveGameVersionUnknown(const std::string& otrPath) {
+    auto archive = std::make_shared<Ship::O2rArchive>(otrPath);
+    if (!archive->Open()) {
+        return false;
+    }
+    auto t = archive->LoadFile("version");
+    if (t == nullptr || !t->IsLoaded || t->Buffer->size() < 5) {
+        return false;
+    }
+    auto stream = std::make_shared<Ship::MemoryStream>(t->Buffer->data(), t->Buffer->size());
+    auto reader = std::make_shared<Ship::BinaryReader>(stream);
+    reader->SetEndianness(static_cast<Ship::Endianness>(reader->ReadUByte()));
+    const uint32_t raw = reader->ReadUInt32();
+    const uint32_t swapped = BSWAP32(raw);
+    return raw != GAME_VERSION_US && raw != GAME_VERSION_JP && swapped != GAME_VERSION_US && swapped != GAME_VERSION_JP;
+}
+
 GameEngine::GameEngine() : dictionary(nullptr) {
     this->context = Ship::Context::CreateInstance("Ghostship", "sm64");
     this->context->Init();
@@ -652,9 +672,13 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
 
     OTRVersion romArchiveVersion = DetectOTRVersion("sm64.o2r");
 
-    bool found = std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("sm64.o2r"));
+    const std::string romO2RPath = Ship::Context::LocateFileAcrossAppDirs("sm64.o2r", "sm64");
+    bool found = std::filesystem::exists(romO2RPath);
     bool shouldRegen = !VerifyArchiveVersion(romArchiveVersion) && romArchiveVersion.major != INT16_MAX &&
                        !(romArchiveVersion.major == 0 && romArchiveVersion.minor == 0 && romArchiveVersion.patch == 0);
+    if (found && IsArchiveGameVersionUnknown(romO2RPath)) {
+        shouldRegen = true;
+    }
 
     std::filesystem::path ownPath;
     std::vector<std::string> args;
@@ -706,7 +730,8 @@ void GameEngine::RunExtract(int argc, char* argv[]) {
         GhostshipGui::RegisterPopup("Outdated ROM Archives",
                                     "Your sm64.o2r was created with incompatible versions of Ghostship.\nYou will "
                                     "now be redirected to re-extract them.");
-        std::filesystem::remove("sm64.o2r");
+        std::error_code ec;
+        std::filesystem::remove(romO2RPath, ec);
     }
 #endif
     std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
@@ -1617,8 +1642,23 @@ uint8_t GameEngine::GetBankIdByName(const std::string& name) {
     return 0;
 }
 
+// The ROM CRC in the sm64.o2r "version" file is byte-swapped in archives from older Torch
+// builds and stored as-is in newer ones, so both orders exist in the wild. Accept either so
+// an existing archive keeps working after an update.
+static uint32_t ResolveGameVersion() {
+    const auto versions = ShipCompat::GetResourceManager()->GetArchiveManager()->GetGameVersions();
+    if (versions.empty()) {
+        return 0;
+    }
+    const uint32_t raw = versions[0];
+    if (raw == GAME_VERSION_US || raw == GAME_VERSION_JP) {
+        return raw;
+    }
+    return BSWAP32(raw);
+}
+
 uint32_t GameEngine::GetGameVersion() {
-    return BSWAP32(ShipCompat::GetResourceManager()->GetArchiveManager()->GetGameVersions()[0]);
+    return ResolveGameVersion();
 }
 
 void GameEngine::RunCommands(Gfx* Commands, const std::vector<FrameInterpolationResult>& replacements) {
@@ -1805,7 +1845,7 @@ extern "C" void GameEngine_UnloadSequence(const uint8_t seqId) {
 }
 
 extern "C" uint32_t GameEngine_GetGameVersion() {
-    return ShipCompat::GetResourceManager()->GetArchiveManager()->GetGameVersions()[0];
+    return ResolveGameVersion();
 }
 
 extern "C" uint8_t* GameEngine_LoadActName(const uint32_t actId) {

--- a/src/port/game/GeoLayoutParser.cpp
+++ b/src/port/game/GeoLayoutParser.cpp
@@ -4,6 +4,9 @@
 #include <libultraship.h>
 
 #include "port/Engine.h"
+extern "C" {
+#include "sm64.h"
+}
 #include "port/events/Events.h"
 #include "port/interpolation/FrameInterpolation.h"
 
@@ -154,7 +157,7 @@ std::unordered_map<uint32_t, GraphNodeEntry> mJPFunctionTable = {
 };
 
 std::unordered_map<uint32_t, std::unordered_map<uint32_t, GraphNodeEntry>> mFunctionTable = {
-    { 0xFF2B5A63, mUSFunctionTable }, { 0xE3DAA4E, mJPFunctionTable }
+    { GAME_VERSION_US, mUSFunctionTable }, { GAME_VERSION_JP, mJPFunctionTable }
 };
 
 GraphNodeFunc GetFunctionByAddr(const uint32_t addr, std::string opcode) {


### PR DESCRIPTION
Follow-up to #246. A version bump covers this for people coming from a release, since the existing "Outdated ROM Archives" check keys on major.minor. This is a small fallback on top of that for the nightly case, where the port version inside the archive stays the same across builds and the check has nothing to key on: a 2.1.0 archive holds the ROM CRC as `ff 2b 5a 63`, a freshly extracted one holds `63 5a 2b ff`, and both say 2.1.0.

**What it does**

- `GetGameVersion()` accepts the CRC in either byte order, so an existing archive keeps working after an update with no prompt. The two supported CRCs are named constants (`GAME_VERSION_US`, `GAME_VERSION_JP`) in sm64.h and used by the geo layout function table.
- The C accessor behind `ROM_JP` uses the same resolver. It had no swap while `GetGameVersion()` did, so with a freshly extracted JP archive the two would disagree.
- If an archive's stored CRC matches neither ROM in either order, it goes through the existing "Outdated ROM Archives" popup and back into extraction. That path now deletes the archive at its located path instead of `sm64.o2r` in the working directory.

Nothing keys on the code version, so rebuilding never forces a re-extract, and the major.minor check is unchanged.

**Verification** (macOS 26.6 arm64, develop 877f6ef8 + this change)

- US, 2.1.0-era archive: title screen, no prompt.
- US, freshly extracted archive: title screen, no prompt.
- JP, freshly extracted from a JP ROM: title screen, file select in Japanese, no prompt.
- Archive with hand-corrupted version bytes: "Outdated ROM Archives" popup, then the "Generate one now?" prompt.
