### PR TITLE
Fix notification stacking and reconnect the Notifications settings

### DIFF
--- a/src/port/ui/Notification.cpp
+++ b/src/port/ui/Notification.cpp
@@ -46,19 +46,20 @@ void Window::Draw() {
             return;
     }
 
-    // Process each notification
-    for (int index = 0; index < notifications.size(); ++index) {
+    // Newest notification sits in the chosen corner; older ones stack away from it,
+    // downward for the top corners and upward for the bottom ones.
+    const bool stackDownward = position == 0 || position == 1;
+    const int count = static_cast<int>(notifications.size());
+    float previousHeight = 0.0f;
+
+    for (int n = 0; n < count; ++n) {
+        int index = count - 1 - n;
         auto& notification = notifications[index];
-        int count = static_cast<int>(notifications.size());
         int inverseIndex = -(count - 1 - index);
 
-        if (index != 0) {
-            auto it = notificationHeights.find(notification.id);
-            if (it != notificationHeights.end()) {
-                basePosition.y -= it->second + padding;
-            } else {
-                basePosition.y -= (notification.isAchievement ? 100.0f : 60.0f) + padding;
-            }
+        if (n != 0) {
+            float step = previousHeight + padding;
+            basePosition.y += stackDownward ? step : -step;
         }
 
         if (notification.isAchievement) {
@@ -68,6 +69,9 @@ void Window::Draw() {
             // Original simple layout for regular notifications
             DrawRegularNotification(notification, basePosition, inverseIndex, position, padding, vp, index);
         }
+
+        auto it = notificationHeights.find(notification.id);
+        previousHeight = it != notificationHeights.end() ? it->second : (notification.isAchievement ? 100.0f : 60.0f);
     }
 }
 

--- a/src/port/ui/Notification.cpp
+++ b/src/port/ui/Notification.cpp
@@ -9,6 +9,7 @@
 
 #include "sounds.h"
 #include "audio/external.h"
+#include "port/ui/cvar_prefixes.h"
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
@@ -24,7 +25,7 @@ void Window::Draw() {
     const float margin = 30.0f;
     const float padding = 10.0f;
 
-    int position = CVarGetInteger("gNotifications.Position", 3);
+    int position = CVarGetInteger(CVAR_SETTING("Notifications.Position"), 3);
 
     // Calculate base position exactly as in legacy code.
     ImVec2 basePosition;
@@ -72,11 +73,14 @@ void Window::Draw() {
 
 void Window::DrawRegularNotification(const Options& notification, ImVec2 basePosition, int inverseIndex, int position,
                                      float padding, ImGuiViewport* vp, int index) {
-    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, CVarGetFloat("gNotifications.BgOpacity", 0.5f)));
+    ImGui::PushStyleColor(ImGuiCol_WindowBg,
+                          ImVec4(0, 0, 0, CVarGetFloat(CVAR_SETTING("Notifications.BgOpacity"), 0.5f)));
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f * CVarGetFloat("gNotifications.Size", 1.8f), 6.0f));
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(8.0f * CVarGetFloat("gNotifications.Size", 1.8f), 8.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                        ImVec2(8.0f * CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f), 6.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                        ImVec2(8.0f * CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f), 8.0f));
 
     ImGui::SetNextWindowViewport(vp->ID);
     if (notification.remainingTime < 4.0f) {
@@ -92,7 +96,7 @@ void Window::DrawRegularNotification(const Options& notification, ImVec2 basePos
                      ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove |
                      ImGuiWindowFlags_NoScrollbar);
 
-    ImGui::SetWindowFontScale(CVarGetFloat("gNotifications.Size", 1.8f));
+    ImGui::SetWindowFontScale(CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f));
 
     ImVec2 currentWinSize = ImGui::GetWindowSize();
     ImVec2 notificationPos;
@@ -116,7 +120,7 @@ void Window::DrawRegularNotification(const Options& notification, ImVec2 basePos
     ImGui::AlignTextToFramePadding();
 
     if (notification.itemIcon != nullptr) {
-        float iconSize = 22 * CVarGetFloat("gNotifications.Size", 1.8f);
+        float iconSize = 22 * CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f);
         ImGui::Image(std::static_pointer_cast<Fast::Fast3dGui>(ShipCompat::GetWindow()->GetGui())
                          ->GetTextureByName(notification.itemIcon),
                      ImVec2(iconSize, iconSize));
@@ -292,7 +296,7 @@ void Window::UpdateElement() {
 void Emit(Options notification) {
     notification.id = nextId++;
     if (notification.remainingTime == 0.0f) {
-        notification.remainingTime = CVarGetFloat("gNotifications.Duration", 10.0f);
+        notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     }
     notifications.push_back(notification);
     if (!notification.mute) {
@@ -314,7 +318,7 @@ void EmitAchievement(const char* iconPath, const std::string& achievementName, i
         notification.suffixColor = ImVec4(1.0f, 0.85f, 0.0f, 1.0f); // Gold
     }
 
-    notification.remainingTime = CVarGetFloat("gNotifications.Duration", 10.0f);
+    notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     notification.isAchievement = true;
 
     notifications.push_back(notification);
@@ -332,7 +336,7 @@ void EmitAchievementProgress(const char* iconPath, const char* name, int current
     notification.prefixColor = ImVec4(0.8f, 0.8f, 0.8f, 1.0f); // Gray
     notification.message = progressText;
     notification.messageColor = ImVec4(0.8f, 0.8f, 0.8f, 1.0f); // Gray
-    notification.remainingTime = CVarGetFloat("gNotifications.Duration", 10.0f);
+    notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     notification.isAchievement = true; // Get achievement styling
 
     notifications.push_back(notification);
@@ -351,7 +355,7 @@ void EmitAchievementProgressWithEvent(const char* iconPath, const char* eventNam
     notification.prefixColor = ImVec4(0.4f, 0.8f, 1.0f, 1.0f); // Light blue
     notification.message = progressText;
     notification.messageColor = ImVec4(0.9f, 0.9f, 0.9f, 1.0f); // Light gray
-    notification.remainingTime = CVarGetFloat("gNotifications.Duration", 10.0f);
+    notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     notification.isAchievement = true; // Get achievement styling
 
     notifications.push_back(notification);


### PR DESCRIPTION
Two related fixes, shipped together because the second exposes the first. Notifications stacked upward from the first one shown, so anchored to a top corner the second notification was drawn above the screen edge, and the newest notification was always the one farthest from the corner. That was invisible in practice because the Settings > Notifications controls (Position, Duration, Size, Background Opacity) have had no effect since the January notification system rewrite: the menu stores them under the gSettings prefix (moved there in #66) while the rewritten drawing code reads the earlier gNotifications names, so every notification used the defaults and Hidden never hid anything. Reconnecting the settings without fixing the stacking would put the off-screen stacking in front of anyone who picks a top corner, so both are here.

**[280714b2](https://github.com/quarrel07/Ghostship/commit/280714b2) Stack notifications away from the chosen corner, newest first**

The newest notification is drawn in the selected corner and older ones stack away from it: downward for the top corners, upward for the bottom ones. Each step uses the height of the notification just drawn, so the regular and achievement popup sizes stack without overlapping.

**[e1f70beb](https://github.com/quarrel07/Ghostship/commit/e1f70beb) Fix the Notifications settings having no effect**

Reads the four values through CVAR_SETTING, matching the menu. No other change.

**Verification**

macOS 26 arm64, develop e323e17f, using the test buttons under Settings > Notifications. Position applies, including Hidden. With Top Left selected the newest notification sits in the corner and older ones stack downward, nothing off-screen. Size, Background Opacity, and Duration apply to the regular notification. The achievement popup keeps its own fixed styling, so Size and Opacity do not affect it; left as is since that looks deliberate, happy to wire them up if wanted. Related: the notifications half of #209.
