### PR TITLE
Fix the Achievements window opening taller than the screen and its score labels overlapping the titles

### DIFF
--- a/src/port/ui/AchievementsWindow.cpp
+++ b/src/port/ui/AchievementsWindow.cpp
@@ -55,7 +55,14 @@ void DrawAchievementCard(const std::pair<const std::string, Achievement>& achPai
 
     ImGui::SameLine();
 
-    ImGui::BeginGroup();
+    // Reserve the score column on the right before laying out the text, so long titles
+    // and descriptions clip at the column instead of running underneath the score.
+    const float scoreWidth = ImGui::CalcTextSize("1000 (G)").x + 20.0f;
+    const float textWidth = ImGui::GetContentRegionAvail().x - scoreWidth - ImGui::GetStyle().ItemSpacing.x;
+
+    ImGui::BeginChild("text", ImVec2(textWidth, cardHeight - 10), false,
+                      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
+                          ImGuiWindowFlags_NoBackground);
 
     // Title
     ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32_WHITE);
@@ -77,18 +84,13 @@ void DrawAchievementCard(const std::pair<const std::string, Achievement>& achPai
                           gCatStyles[ach.category].color);
     ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
 
-    // 3. This now stretches to the edge of the card, leaving a perfect 10px margin
-    ImGui::ProgressBar(progress, ImVec2(-10.0f, 21.0f), progBuf);
+    ImGui::ProgressBar(progress, ImVec2(-1.0f, 21.0f), progBuf);
     ImGui::PopStyleColor(2);
 
-    ImGui::EndGroup();
+    ImGui::EndChild();
 
     // Satella Score
     ImGui::SameLine();
-
-    float contentRegionMaxX = ImGui::GetWindowContentRegionMax().x;
-    float scoreWidth = ImGui::CalcTextSize("1000 G").x + 30.0f;
-    ImGui::SetCursorPosX(contentRegionMaxX - scoreWidth);
 
     ImGui::BeginGroup();
     ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32_WHITE);

--- a/src/port/ui/GhostshipGui.cpp
+++ b/src/port/ui/GhostshipGui.cpp
@@ -94,7 +94,8 @@ void SetupGuiElements() {
     mConsoleWindow = std::make_shared<Ship::ConsoleWindow>(CVAR_WINDOW("DevConsole"), "Console##Dev", ImVec2(820, 630));
     gui->AddGuiWindow(mConsoleWindow);
 
-    mAchievementsWindow = std::make_shared<AchievementsWindow>(CVAR_WINDOW("Achievements"), "Achievements");
+    mAchievementsWindow =
+        std::make_shared<AchievementsWindow>(CVAR_WINDOW("Achievements"), "Achievements", ImVec2(960, 720));
     gui->AddGuiWindow(mAchievementsWindow);
 
     mEventDebuggerWindow = std::make_shared<Ship::EventDebuggerWindow>(CVAR_WINDOW("EventDebugger"), "Event Debugger");


### PR DESCRIPTION
Opening Popout Achievements gave a window sized to its full content, taller than the display with the bottom rows unreachable, and on the shipped macOS build resizing that window after dragging it out left the content at the wrong scale with an unpainted region beside it. The card layout also drew each achievement's score on top of its title.

**[66777905](https://github.com/quarrel07/Ghostship/commit/66777905) Give the Achievements window a default size**

The window was created without one, so ImGui sized it to its content on first use. Start it at 960x720 like the other tool windows; it scrolls and can be resized from there. On macOS this also removes the trigger for the broken resize: with a window that fits the display, dragging it out and resizing it works normally. Not a fix for whatever SDL does with the oversized window, just no longer hitting it.

**[c024ab95](https://github.com/quarrel07/Ghostship/commit/c024ab95) Keep the achievement score label off the titles**

Each card laid out its title, description, and progress bar across the full card width and then drew the score at the right edge on the same row, so the score landed on the title. Reserve the score column first and lay the text out in the remaining width, clipping at the column instead of running under the score.

**Verification**

macOS 26 arm64, develop d671cb86, using the SDL library from the official 3.0.0 build. Before: pop-out taller than the display; dragging it out and resizing shrank the content and showed an unpainted region. After: opens at 960x720, drags out and resizes normally, score labels in their own column. Related: the pop-out half of #209's follow-up.
