### PR TITLE
Web: make first-run ROM extraction work in Safari and Chrome on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,7 @@ if(EMSCRIPTEN)
         -sSTACK_SIZE=5242880
         -sPTHREAD_POOL_SIZE=8
         -sASYNCIFY=1
+        "-sASYNCIFY_REMOVE=@${CMAKE_SOURCE_DIR}/src/port/web/asyncify-remove.txt"
         -sASSERTIONS=1
         -sASYNCIFY_STACK_SIZE=8388608
         -sFORCE_FILESYSTEM=1
@@ -391,7 +392,8 @@ if(EMSCRIPTEN)
             "SHELL:--preload-file ${GHOSTSHIP_WEB_PRELOAD_ROM}@/sm64.o2r")
     endif()
     set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY LINK_DEPENDS
-        "${CMAKE_SOURCE_DIR}/src/port/web/shell.html")
+        "${CMAKE_SOURCE_DIR}/src/port/web/shell.html"
+        "${CMAKE_SOURCE_DIR}/src/port/web/asyncify-remove.txt")
     add_custom_command(
         TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/src/port/GameExtractor.cpp
+++ b/src/port/GameExtractor.cpp
@@ -328,6 +328,10 @@ bool GameExtractor::GenerateOTRTo(std::atomic<size_t>& assetCount, const std::st
     this->WritePortVersion();
     try {
         Companion::Instance->Init(ExportType::Binary, assetCount, true);
+#ifdef __EMSCRIPTEN__
+        // Torch's Init() skips Process() on the web build, so run the export pass here like Parse() does.
+        Companion::Instance->Process(assetCount);
+#endif
     } catch (const std::exception& e) {
         sLastError = e.what();
         SPDLOG_ERROR("Failed to process O2R: {}", e.what());

--- a/src/port/GameExtractor.cpp
+++ b/src/port/GameExtractor.cpp
@@ -329,7 +329,8 @@ bool GameExtractor::GenerateOTRTo(std::atomic<size_t>& assetCount, const std::st
     try {
         Companion::Instance->Init(ExportType::Binary, assetCount, true);
     } catch (const std::exception& e) {
-        SPDLOG_INFO("Failed to process O2R {}", e.what());
+        sLastError = e.what();
+        SPDLOG_ERROR("Failed to process O2R: {}", e.what());
         return false;
     }
 

--- a/src/port/web/WebUtils.cpp
+++ b/src/port/web/WebUtils.cpp
@@ -56,112 +56,83 @@ void WebCache_Save() {
     js_idbfs_save();
 }
 
-EM_ASYNC_JS(char*, js_pick_rom, (), {
-    return new Promise(function(resolve) {
-        var input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.z64,.n64,.v64';
-
-        input.addEventListener(
-            'change', function(evt) {
-                var file = evt.target.files[0];
-                if (!file) {
-                    resolve(0);
-                    return;
-                }
-
-                var reader = new FileReader();
-                reader.onload = function(re) {
-                    var data = new Uint8Array(re.target.result);
-                    var vpath = '/tmp/rom.z64';
-                    FS.writeFile(vpath, data);
-                    // Return the path as a malloc'd C string; caller must free().
-                    var len = lengthBytesUTF8(vpath) + 1;
-                    var ptr = _malloc(len);
-                    stringToUTF8(vpath, ptr, len);
-                    resolve(ptr);
-                };
-                reader.onerror = function() {
-                    resolve(0);
-                };
-                reader.readAsArrayBuffer(file);
-            });
-
-        // If the dialog is closed without a selection the Promise never fires
-        // otherwise, so also listen on the body focus-return as a heuristic.
-        input.addEventListener(
-            'cancel', function() { resolve(0); });
-
-        input.style.display = 'none';
-        document.body.appendChild(input);
-        input.click();
-        // Remove from DOM immediately; the file dialog stays open.
-        setTimeout(
-            function() {
-                if (input.parentNode)
-                    input.parentNode.removeChild(input);
-            },
-            500);
-    });
-});
-
-std::string WebFilePicker_PickROM() {
-    char* ptr = js_pick_rom();
-    if (!ptr)
-        return "";
-    std::string path(ptr);
-    free(ptr);
-    return path;
-}
-
-EM_ASYNC_JS(int, js_pick_into, (const char* caccept, const char* cdest), {
+// Shows an in-page prompt with a real button and opens the file dialog from that
+// button's click handler. Safari only opens a file dialog from inside a user
+// gesture, and the game loop is not one, so a programmatic click issued from a
+// later frame is silently ignored and the Promise would never settle. The
+// <input> stays in the document until the dialog reports a file or the user
+// cancels, since some browsers drop the change event for a detached input.
+// clang-format off
+EM_ASYNC_JS(int, js_pick_into, (const char* ctitle, const char* caccept, const char* cdest), {
+    var title = UTF8ToString(ctitle);
     var accept = UTF8ToString(caccept);
     var dest = UTF8ToString(cdest);
     return new Promise(function(resolve) {
+        var overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;inset:0;display:flex;align-items:center;justify-content:center;' +
+                                'background:rgba(0,0,0,0.65);z-index:1000;font-family:system-ui,sans-serif;';
+        var panel = document.createElement('div');
+        panel.style.cssText = 'background:#1c1c24;color:#eee;padding:24px 28px;border-radius:12px;text-align:center;' +
+                              'max-width:90vw;box-shadow:0 8px 32px rgba(0,0,0,0.5);';
+        var label = document.createElement('p');
+        label.textContent = title;
+        label.style.cssText = 'margin:0 0 16px 0;font-size:1rem;';
         var input = document.createElement('input');
         input.type = 'file';
         input.accept = accept;
-
-        input.addEventListener(
-            'change', function(evt) {
-                var file = evt.target.files[0];
-                if (!file) {
-                    resolve(0);
-                    return;
-                }
-                var reader = new FileReader();
-                reader.onload = function(re) {
-                    var data = new Uint8Array(re.target.result);
-                    try {
-                        FS.writeFile(dest, data);
-                        resolve(1);
-                    } catch (e) {
-                        console.error('[WebFilePicker] write failed:', e);
-                        resolve(0);
-                    }
-                };
-                reader.onerror = function() {
-                    resolve(0);
-                };
-                reader.readAsArrayBuffer(file);
-            });
-        input.addEventListener(
-            'cancel', function() { resolve(0); });
-
         input.style.display = 'none';
-        document.body.appendChild(input);
-        input.click();
-        setTimeout(
-            function() {
-                if (input.parentNode)
-                    input.parentNode.removeChild(input);
-            },
-            500);
+        var choose = document.createElement('button');
+        choose.textContent = 'Choose File';
+        choose.style.cssText = 'font-size:1rem;padding:8px 18px;margin:0 6px;cursor:pointer;';
+        var cancel = document.createElement('button');
+        cancel.textContent = 'Cancel';
+        cancel.style.cssText = choose.style.cssText;
+        var settled = false;
+        function finish(result) {
+            if (settled) return;
+            settled = true;
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+            resolve(result);
+        }
+        input.addEventListener('change', function(evt) {
+            var file = evt.target.files[0];
+            if (!file) { finish(0); return; }
+            var reader = new FileReader();
+            reader.onload = function(re) {
+                try {
+                    FS.writeFile(dest, new Uint8Array(re.target.result));
+                    finish(1);
+                } catch (e) {
+                    console.error('[WebFilePicker] write failed:', e);
+                    finish(0);
+                }
+            };
+            reader.onerror = function() { finish(0); };
+            reader.readAsArrayBuffer(file);
+        });
+        input.addEventListener('cancel', function() { /* keep the prompt; the user can retry or cancel */ });
+        choose.addEventListener('click', function() { input.click(); });
+        cancel.addEventListener('click', function() { finish(0); });
+        panel.appendChild(label);
+        panel.appendChild(input);
+        panel.appendChild(choose);
+        panel.appendChild(cancel);
+        overlay.appendChild(panel);
+        document.body.appendChild(overlay);
     });
 });
+// clang-format on
+
+std::string WebFilePicker_PickROM() {
+    const char* vpath = "/tmp/rom.z64";
+    if (!js_pick_into("Choose your Super Mario 64 ROM (.z64, .n64, or .v64)", ".z64,.n64,.v64", vpath)) {
+        return "";
+    }
+    return vpath;
+}
 
 bool WebFilePicker_PickInto(const char* accept, const char* destPath) {
-    return js_pick_into(accept, destPath) != 0;
+    return js_pick_into("Choose the file to load", accept, destPath) != 0;
 }
 
 #endif // __EMSCRIPTEN__

--- a/src/port/web/asyncify-remove.txt
+++ b/src/port/web/asyncify-remove.txt
@@ -1,0 +1,21 @@
+# Functions Asyncify must not instrument in the browser build.
+#
+# Asyncify flattens every instrumented function into thousands of wasm locals,
+# and Safari keeps those locals on the worker's native stack. Torch runs on the
+# extraction thread and never suspends, so instrumenting it only overflows that
+# stack ("Maximum call stack size exceeded" after "Starting Torch").
+Companion::*
+Torch::*
+BaseFactory::*
+SM64::*
+OoT::*
+BK64::*
+PM64Audio::*
+MK64::*
+SF64::*
+N64::*
+YAML::*
+prism::*
+Decompressor::*
+miniz_cpp::*
+*GetSafeNode*

--- a/src/port/web/shell.html
+++ b/src/port/web/shell.html
@@ -91,7 +91,12 @@
     var Module = {
       canvas: (function() { return document.getElementById('canvas'); })(),
 
-      print: function(text) { console.log('[WASM]', text); },
+      // Torch logs every asset at info level, and console.log is slow enough that it
+      // dominated extraction time. Info and below still go to the log file in /storage/logs.
+      print: function(text) {
+        if (/\] \[(info|debug|trace)\] /.test(text)) return;
+        console.log('[WASM]', text);
+      },
       printErr: function(text) { console.warn('[WASM]', text); },
 
       setStatus: function(text) {


### PR DESCRIPTION
Gets ROM extraction working in the web build on macOS, tested in Safari 26 and Chrome 152. Three things were in the way: Safari wouldn't open the file picker, the extraction worker overflowed its stack in Safari, and the export pass never ran in either browser, so nothing was written and the "No ROM O2R file detected" popup showed up at the end. One commit per fix below, plus a console change that speeds extraction up in every browser.

### [0513e003](https://github.com/quarrel07/Ghostship/commit/0513e003) Web: open the file picker from a real click so Safari shows it

Safari only opens a file dialog from inside a user gesture, and the game loop is not one, so the programmatic click was ignored and the promise never settled. The picker now shows a small overlay with a Choose File button that owns the click, and the input stays in the document until the dialog reports a file or the user cancels.

### [03ce0069](https://github.com/quarrel07/Ghostship/commit/03ce0069) Record the extractor's error so the failure popup can show it

Torch's exception text was only logged, and the popup always said "No ROM O2R file detected". The popup now shows the actual message when there is one.

### [d5b4bb0d](https://github.com/quarrel07/Ghostship/commit/d5b4bb0d) Web: leave Torch out of Asyncify instrumentation

Asyncify flattens every instrumented function into thousands of wasm locals (Companion::Process had 13,007), and Safari keeps those on the worker's native stack, so the first three Torch frames overflowed it right after "Starting Torch". The extraction thread never suspends, so Torch does not need the instrumentation. A small list file excludes the Torch namespaces; Process drops to 866 locals and the wasm shrinks by about 5 MB.

### [530a22a1](https://github.com/quarrel07/Ghostship/commit/530a22a1) Web: run Torch's export pass when generating the archive

Torch's Init() skips Process() under Emscripten and expects the caller to run it. Parse() already does that for the counting pass, but GenerateOTRTo() did not, so the second pass registered its factories and returned without writing anything. This mirrors the existing call.

### [ae2bdaf1](https://github.com/quarrel07/Ghostship/commit/ae2bdaf1) Web: keep info-level log lines out of the browser console

Torch logs every asset at info level, about 160,000 console.log calls per extraction, and that dominated the run: in headless Chrome the two passes take 31.3 s with the lines and 19.8 s without them (two runs each, within 0.1 s). Warnings and errors still reach the console, and the full log is still written to /storage/logs.

### Verification

Local Emscripten 4.0.12 build, tested on macOS 26 in Chrome 152 and Safari 26: the picker appears, both passes complete (with the export pass showing progress), sm64.o2r is written (10.2 MB), and the game boots to the title screen. Reloading the page finds the persisted archive and skips the prompt. I could not try Windows or Linux browsers, so if the export pass behaves differently for you there, that would be good to know. The in-game issues visible after this (ImGui DPI scaling, fullscreen toggling, the audio backend list) are separate and not touched here.
