### PR TITLE
Restore "Press start to play!" voice line after title screen demo

### DIFF
--- a/levels/intro/script.c
+++ b/levels/intro/script.c
@@ -47,6 +47,9 @@ const LevelScript level_intro_mario_head_regular[] = {
     INIT_LEVEL(),
     BLACKOUT(/*active*/ TRUE),
     FIXED_LOAD(/*loadAddr*/ _goddardSegmentStart, /*romStart*/ _goddardSegmentRomStart, /*romEnd*/ _goddardSegmentRomEnd),
+           // The N64 reloads the title screen code and data during FIXED_LOAD above; reset its statics
+           // the same way so Mario greets the player again after a demo.
+           CALL(/*arg*/ 0, /*func*/ lvl_init_title_screen_values),
     LOAD_MARIO_HEAD(/*loadHeadID*/ REGULAR_FACE),
     LOAD_RAW(/*seg*/ 0x13, _behaviorSegmentRomStart, _behaviorSegmentRomEnd),
     LOAD_MIO0_TEXTURE(/*seg*/ 0x0A, _title_screen_bg_mio0SegmentRomStart, _title_screen_bg_mio0SegmentRomEnd),
@@ -72,6 +75,9 @@ const LevelScript level_intro_mario_head_dizzy[] = {
     INIT_LEVEL(),
     BLACKOUT(/*active*/ TRUE),
     FIXED_LOAD(/*loadAddr*/ _goddardSegmentStart, /*romStart*/ _goddardSegmentRomStart, /*romEnd*/ _goddardSegmentRomEnd),
+           // The N64 reloads the title screen code and data during FIXED_LOAD above; reset its statics
+           // the same way so Mario greets the player again after a demo.
+           CALL(/*arg*/ 0, /*func*/ lvl_init_title_screen_values),
     LOAD_MARIO_HEAD(/*loadHeadID*/ DIZZY_FACE),
     LOAD_RAW(/*seg*/ 0x13, _behaviorSegmentRomStart, _behaviorSegmentRomEnd),
     LOAD_MIO0_TEXTURE(/*seg*/ 0x0A, _title_screen_bg_mio0SegmentRomStart, _title_screen_bg_mio0SegmentRomEnd),

--- a/src/menu/title_screen.c
+++ b/src/menu/title_screen.c
@@ -157,6 +157,19 @@ s16 intro_level_select(void) {
 }
 
 /**
+ * On the N64 this file is part of the goddard overlay, which FIXED_LOAD copies fresh
+ * from ROM each time the title screen is entered, so the greeting re-arms and the
+ * demo countdown restarts after every demo. Without segmented memory the statics
+ * persist, so reset them at the point the reload would have happened.
+ */
+s32 lvl_init_title_screen_values(UNUSED s16 arg0, UNUSED s32 arg1) {
+    sPlayMarioGreeting = TRUE;
+    sPlayMarioGameOver = TRUE;
+    sDemoCountdown = 0;
+    return 0;
+}
+
+/**
  * Regular intro function that handles Mario's greeting voice and game start.
  */
 s32 intro_regular(void) {

--- a/src/menu/title_screen.h
+++ b/src/menu/title_screen.h
@@ -13,5 +13,6 @@ enum LevelScriptIntroArgs {
 };
 
 extern_s s32 lvl_intro_update(s16 arg, UNUSED s32 unusedArg);
+extern_s s32 lvl_init_title_screen_values(UNUSED s16 arg0, UNUSED s32 arg1);
 
 #endif // TITLE_SCREEN_H


### PR DESCRIPTION
Fixes #119.

On the N64 the title screen code (src/menu/title_screen.c) is part of the goddard overlay, which the intro scripts copy fresh from ROM with FIXED_LOAD every time the Mario head screen is entered, after zeroing the region. That reload re-arms sPlayMarioGreeting and sPlayMarioGameOver and restarts sDemoCountdown, so on hardware Mario says "Press start to play!" after every demo. The port keeps those statics across the reload, so the greeting only came back after pressing Start.

This adds lvl_init_title_screen_values(), which resets those three values, and calls it from the two intro scripts right after their FIXED_LOAD, the same way levels/menu/script.c already calls lvl_init_act_selector_values_and_stars for sVisibleStars.

Tested on macOS (arm64): stock never plays the line after a demo; the fixed build plays "Press start to play!" each time the head returns after a demo, through the whole demo rotation. The first-boot "Hello!" is unchanged.
