### PR TITLE
Fix: Save fullscreen, window size and position when the game quits

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1466,6 +1466,14 @@ void GameEngine::Create(int argc, char* argv[]) {
 
 void GameEngine::Destroy() {
     GhostshipGui::Destroy();
+    // Persist the window state (fullscreen, size, position) here. GameEngine::Instance is never deleted, so the
+    // Ship::Context it holds is never destroyed and the save in Context::~Context never runs on quit.
+    if (auto window = ShipCompat::GetWindow()) {
+        window->SaveWindowToConfig();
+    }
+    if (auto config = ShipCompat::GetConfig()) {
+        config->Save();
+    }
     gsFast3dWindow = nullptr;
     AudioExit();
 #ifdef __SWITCH__


### PR DESCRIPTION
Ghostship only writes the fullscreen state, window size and window position to the config when the Ship::Context is destroyed, and that never happens on quit: GameEngine::Instance is created once and never deleted, so the context it holds stays alive until the process ends and Context::~Context never runs. Those values only reached disk when some other setting change happened to save the config afterward, which is why toggling fullscreen and quitting did not stick (reported on Discord by DementisXYZ and masterotaku) while editing Window.Fullscreen.Enabled by hand did.

This saves the window state and flushes the config in GameEngine::Destroy(), which is the normal quit path for the menu Quit button, Cmd+Q and the window close button. Nothing else about shutdown changes.

Tested on macOS (arm64, Metal) against a stock build from the same tree: started fullscreen and windowed, quit, and checked the file. Stock never touched the config at quit; with this change the file is written at quit with the live state, including the fullscreen dimensions. Also toggled fullscreen from the Ghostship menu in a windowed session and quit: the next launch came up fullscreen.

One adjacent thing I noticed but did not change since I cannot test on Windows: in libultraship's gfx_dxgi.cpp, SetFullscreenChangedCallback assigns its parameter to itself, so the DX11 window never stores the callback. This change does not depend on it because it reads the live fullscreen state at quit.
