### PR TITLE
Keep Mirrored World mirrored while paused and during demos

### DIFF
--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -19,11 +19,9 @@ extern int mirror_mode_is_enabled(void);
 extern void mirror_mode_undo_projection(void);
 extern int mirror_mode_is_active(void);
 extern s16 gCurrLevelNum;
-extern s16 sCurrPlayMode;
 extern s32 gCurrCreditsEntry;
 extern struct MarioState *gMarioState;
-
-#define PLAY_MODE_NORMAL 0
+extern struct Object *gMarioObject;
 
 /**
  * This file contains the code that processes the scene graph for rendering.
@@ -277,9 +275,10 @@ void geo_process_perspective(struct GraphNodePerspective *node) {
 
         gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(mtx), G_MTX_PROJECTION | G_MTX_LOAD | G_MTX_NOPUSH);
 
-        // Apply mirror mode transform after perspective projection
-        // Mirror during: normal gameplay, ending cutscenes, but NOT during credits text rendering
-        if (sCurrPlayMode == PLAY_MODE_NORMAL && gMarioState != NULL && gMarioState->action != 0 && gCurrCreditsEntry == NULL) {
+        // Apply mirror mode transform after perspective projection.
+        // Key on Mario's object rather than the play mode so the world stays mirrored
+        // while paused and during warp fades, but not on the title/file select or credits.
+        if (gMarioObject != NULL && gMarioState != NULL && gMarioState->action != 0 && gCurrCreditsEntry == NULL) {
             mirror_mode_apply_projection();
         }
 

--- a/src/port/mods/mirror/MirrorMode.cpp
+++ b/src/port/mods/mirror/MirrorMode.cpp
@@ -120,6 +120,13 @@ void mirror_mode_invert_input(void) {
         return;
     }
 
+    // Demo inputs were recorded against the unmirrored world, so inverting them
+    // sends demo Mario the wrong way. Leave them alone unless the player is
+    // controlling the demo.
+    if (gCurrDemoInput != NULL && CVarGetInteger(CVAR_CHEAT("PlayInDemo"), 0) == 0) {
+        return;
+    }
+
     struct Controller* ctrl = gPlayer1Controller;
     if (ctrl == NULL) {
         return;


### PR DESCRIPTION
Fixes #212, Fixes #255.

**[e08e80cd](https://github.com/quarrel07/Ghostship/commit/e08e80cd) Keep the world mirrored while paused and during warp fades**

The projection flip in geo_process_perspective was gated on the normal play mode, so the frame the pause screen came up (and the fades around warps) rendered unmirrored. It is now gated on Mario's object being loaded, which stays true through pause and warp transitions and is false on the title screen, the file select, and after Save and Quit, so those stay unmirrored as before. The pause menu itself is drawn after the mirror is undone, so it stays readable.

**[45176f37](https://github.com/quarrel07/Ghostship/commit/45176f37) Do not invert demo inputs**

Demo inputs are recorded against the unmirrored world. Inverting them like a player's stick sent demo Mario the wrong way. The inversion is skipped while a demo is driving input unless the Play In Demo cheat is on.

Tested on macOS (arm64) with Mirrored World on: demo Mario follows his route mirrored, the world stays mirrored behind the pause menu with no flash and the menu text reads normally, and the castle door fade stays mirrored. Title screen and file select unchanged.
