### PR TITLE
Fix rank achievements firing early, D Rank never firing, and unlocks lost before the next save

### DIFF
--- a/src/port/data/Saves.cpp
+++ b/src/port/data/Saves.cpp
@@ -51,6 +51,36 @@ void SaveFileDoSave(int32_t fileIndex) {
     file.close();
 }
 
+// Rewrite only the achievement block of an existing save file. Used when an
+// achievement unlocks, so it is kept without committing game progress the
+// player has not chosen to save yet.
+void SaveFileSaveAchievements(int32_t fileIndex) {
+    fs::path filepath = SavesPath() / ("save_" + std::to_string(fileIndex) + ".json");
+    if (!fs::exists(filepath)) {
+        return;
+    }
+
+    json j;
+    try {
+        std::ifstream in(filepath, std::ios::in);
+        if (!in.is_open()) {
+            return;
+        }
+        in >> j;
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("Failed to read save file {} for achievement update: {}", filepath.string(), e.what());
+        return;
+    }
+
+    j["shipSaveData"]["achievementSaveData"] = gSaveBuffer.files[fileIndex][0].shipSaveData.achievementSaveData;
+
+    std::ofstream out(filepath, std::ios::out);
+    if (!out.is_open()) {
+        return;
+    }
+    out << j.dump(1);
+}
+
 bool ShouldLoadOldSaveFile(void) {
     return fs::exists(Ship::Context::GetPathRelativeToAppDirectory("default.sav"));
 }

--- a/src/port/data/Saves.h
+++ b/src/port/data/Saves.h
@@ -9,6 +9,7 @@
 extern_s void RestoreMainMenuData(int32_t srcSlot);
 extern_s void RestoreSaveFileData(int32_t fileIndex, int32_t srcSlot);
 extern_s void SaveFileDoSave(int32_t fileIndex);
+extern_s void SaveFileSaveAchievements(int32_t fileIndex);
 extern_s void SaveFileLoadAll(void);
 extern_s void SaveMainMenuData(void);
 extern_s bool ShouldLoadOldSaveFile(void);

--- a/src/port/mods/achievements/Achievements.cpp
+++ b/src/port/mods/achievements/Achievements.cpp
@@ -438,8 +438,9 @@ void Achievements_Init() {
             SPDLOG_INFO("Coin Collected: {}", ev->marioState->numCoins + 1);
             gCoinsCollected += ev->object->oDamageOrCoinValue;
 
+            // The event fires before the coin is added, and red/blue coins are worth more than one.
             if (gCourseCoinLimits.contains(gCurrCourseNum) &&
-                ev->marioState->numCoins + 1 >= gCourseCoinLimits[gCurrCourseNum]) {
+                ev->marioState->numCoins + ev->object->oDamageOrCoinValue >= gCourseCoinLimits[gCurrCourseNum]) {
                 Achievement_Progress("GetAllCoinsOneLevel");
             }
         }

--- a/src/port/mods/achievements/Achievements.cpp
+++ b/src/port/mods/achievements/Achievements.cpp
@@ -9,6 +9,7 @@
 #include "seq_ids.h"
 #include "port/ui/cvar_prefixes.h"
 #include "game/save_file.h"
+#include "port/data/Saves.h"
 #include "buffers/buffers.h"
 #include "fast/Fast3dGui.h"
 #include "fast/Fast3dWindow.h"
@@ -165,6 +166,31 @@ Achievement* Achievement_FindByID(const std::string& id) {
     return &gAchievementList[id];
 }
 
+static void Achievement_SyncSaveData(AchievementSaveData* saveData) {
+    saveData->cheated = false; // TODO: Implement cheat detection
+
+    if (!saveData->cheated) {
+        size_t index = 0;
+        for (const auto& [id, progress] : gAchievementProgress) {
+            saveData->entries[index].id = id.c_str();
+            saveData->entries[index].progress = progress.progress;
+            index++;
+        }
+        saveData->capStars = gMetalCapStars;
+        saveData->coins = gCoinsCollected;
+    }
+}
+
+// Write an unlock straight into the save file's achievement block so it survives
+// quitting before the next game save. The ending achievements never get one otherwise.
+static void Achievement_PersistUnlock() {
+    if (!HAS_ACHIEVEMENTS(selectedFile) || gDebugLevelSelect) {
+        return;
+    }
+    Achievement_SyncSaveData(&gSaveBuffer.files[selectedFile]->shipSaveData.achievementSaveData);
+    SaveFileSaveAchievements(selectedFile);
+}
+
 void Achievement_Progress(const std::string& id, const int32_t amount) {
     const Achievement* achievement = Achievement_FindByID(id);
     if (achievement) {
@@ -175,6 +201,7 @@ void Achievement_Progress(const std::string& id, const int32_t amount) {
             if (progress >= achievement->maxProgress) {
                 achieved = true;
                 Notification::EmitAchievement(achievement->icon, achievement->name, 0);
+                Achievement_PersistUnlock();
             } else {
                 SPDLOG_INFO("Progressed achievement {}: {}/{}", achievement->name, progress, achievement->maxProgress);
             }
@@ -207,9 +234,8 @@ void Achievement_ProgressByCategory(AchievementCategory category, int32_t amount
                 if (progress >= achievement.maxProgress) {
                     achieved = true;
                     Notification::EmitAchievement(achievement.icon, achievement.name, 0);
+                    Achievement_PersistUnlock();
                 }
-
-                // Save after each achievement progress update to prevent loss of progress on crash
             }
         }
     }
@@ -292,20 +318,7 @@ void Achievements_Save(IEvent* event) {
         return;
     }
 
-    AchievementSaveData* saveData = &gSaveBuffer.files[selectedFile]->shipSaveData.achievementSaveData;
-
-    saveData->cheated = false; // TODO: Implement cheat detection
-
-    if (!saveData->cheated) {
-        size_t index = 0;
-        for (const auto& [id, progress] : gAchievementProgress) {
-            saveData->entries[index].id = id.c_str();
-            saveData->entries[index].progress = progress.progress;
-            index++;
-        }
-        saveData->capStars = gMetalCapStars;
-        saveData->coins = gCoinsCollected;
-    }
+    Achievement_SyncSaveData(&gSaveBuffer.files[selectedFile]->shipSaveData.achievementSaveData);
 }
 
 void Achievements_Init() {

--- a/src/port/mods/achievements/Achievements.cpp
+++ b/src/port/mods/achievements/Achievements.cpp
@@ -129,6 +129,16 @@ std::unordered_map<int16_t, int16_t> gCourseCoinLimits = {
     { COURSE_WDW, 152 }, { COURSE_TTM, 137 }, { COURSE_THI, 192 }, { COURSE_TTC, 128 }, { COURSE_RR, 146 },
 };
 
+// Stars held in a range of main courses only. save_file_get_total_star_count adds the
+// castle secret star slot to every range, which is not what the floor ranks want.
+static int32_t Achievement_CountCourseStars(int32_t slot, int32_t minCourse, int32_t maxCourse) {
+    int32_t count = 0;
+    for (int32_t course = minCourse; course <= maxCourse; course++) {
+        count += save_file_get_course_star_count(slot, COURSE_NUM_TO_INDEX(course));
+    }
+    return count;
+}
+
 int Achievement_GetObjectCount(std::vector<int32_t> models) {
     int count = 0;
     for (int i = 0; i < NUM_OBJ_LISTS; i++) {
@@ -323,7 +333,8 @@ void Achievements_Init() {
                         starIndex, gCurrActNum, starFlags);
             SPDLOG_INFO("Collected already? {}\nGrand Star? {}", (starFlags & (1 << starIndex)) != 0, grandStar);
 
-            if (!(starFlags & (1 << starIndex)) && !grandStar) {
+            const bool newStar = !(starFlags & (1 << starIndex)) && !grandStar;
+            if (newStar) {
                 Achievement_ProgressByCategory(AchievementCategory::Stars, 1);
             }
 
@@ -331,16 +342,13 @@ void Achievements_Init() {
                 Achievement_Progress("Get100CoinStar");
             }
 
-            // If we only rely on the save's star flags, this won't trigger until we collect
-            // an already collected star. Instead, we need to check whether the not-collected
-            // star *would* complete the set and progress the achievement.
-            if ((starFlags | (1 << starIndex)) == 0x3F) {
+            // Star save flags are not updated yet at this point, so the star being collected
+            // has to be counted by hand: only when it is new, and only toward the range it
+            // belongs to. Bit 6 is the 100 coin star, which is not one of the six main stars.
+            if (COURSE_IS_MAIN_COURSE(gCurrCourseNum) && ((starFlags | (1 << starIndex)) & 0x3F) == 0x3F) {
                 Achievement_Progress("Get6MainStars");
             }
 
-            // For these, we have to factor in the star that was just collected,
-            // since star save flags aren't updated by this point.
-            // BOB, WF, JRB, CCM, BBH
             SPDLOG_INFO(
                 "TOTAL STARS:\nFLOOR 1: {}\nBASEMENT: {}\nFLOOR 2: {}\nCOURSE STARS: {}\nCASTLE STARS: {}\nALL "
                 "STARS: {}",
@@ -350,41 +358,42 @@ void Achievements_Init() {
                 save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_BOB), COURSE_NUM_TO_INDEX(COURSE_RR)),
                 save_file_get_course_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_NONE)),
                 save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_MIN), COURSE_NUM_TO_INDEX(COURSE_MAX)));
-            if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_BOB), COURSE_NUM_TO_INDEX(COURSE_BBH)) +
-                    1 >=
-                35) {
+            const bool newMainCourseStar = newStar && COURSE_IS_MAIN_COURSE(gCurrCourseNum);
+            const bool newCastleStar = newStar && !COURSE_IS_MAIN_COURSE(gCurrCourseNum);
+            auto newStarIn = [&](int16_t minCourse, int16_t maxCourse) {
+                return newMainCourseStar && gCurrCourseNum >= minCourse && gCurrCourseNum <= maxCourse ? 1 : 0;
+            };
+
+            // BOB, WF, JRB, CCM, BBH
+            if (Achievement_CountCourseStars(slot, COURSE_BOB, COURSE_BBH) + newStarIn(COURSE_BOB, COURSE_BBH) >= 35) {
                 Achievement_Progress("GetAllStarsInFloor1");
             }
 
             // HMC, LLL, SSL, DDD
-            if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_HMC), COURSE_NUM_TO_INDEX(COURSE_DDD)) +
-                    1 >=
-                28) {
+            if (Achievement_CountCourseStars(slot, COURSE_HMC, COURSE_DDD) + newStarIn(COURSE_HMC, COURSE_DDD) >= 28) {
                 Achievement_Progress("GetAllStarsInBasement");
             }
 
             // SL, WDW, TTM, THI, TTC, RR
-            if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_SL), COURSE_NUM_TO_INDEX(COURSE_RR)) +
-                    1 >=
-                42) {
+            if (Achievement_CountCourseStars(slot, COURSE_SL, COURSE_RR) + newStarIn(COURSE_SL, COURSE_RR) >= 42) {
                 Achievement_Progress("GetAllStarsInFloor2");
             }
 
-            if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_BOB), COURSE_NUM_TO_INDEX(COURSE_RR)) +
-                    1 >=
-                105) {
+            if (Achievement_CountCourseStars(slot, COURSE_BOB, COURSE_RR) + newStarIn(COURSE_BOB, COURSE_RR) >= 105) {
                 Achievement_Progress("GetAllCourseStars");
             }
 
+            // Castle stars live in the secret course slots plus the toad/MIPS file flags,
+            // which is exactly what the bonus-stage range of the total helper adds up.
             if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_BONUS_STAGES),
                                                COURSE_NUM_TO_INDEX(COURSE_MAX)) +
-                    1 >=
+                    (newCastleStar ? 1 : 0) >=
                 15) {
                 Achievement_Progress("GetAllCastleStars");
             }
 
             if (save_file_get_total_star_count(slot, COURSE_NUM_TO_INDEX(COURSE_MIN), COURSE_NUM_TO_INDEX(COURSE_MAX)) +
-                    1 >=
+                    (newStar ? 1 : 0) >=
                 120) {
                 Achievement_Progress("Get120Stars");
             }


### PR DESCRIPTION
Fixes #202.

**[beb24442](https://github.com/quarrel07/Ghostship/commit/beb24442) Count only new, in-range stars toward the rank achievements**

The floor and course rank checks added one to the range's star count for any star collected, including re-collected stars and stars from other floors, and the range helper also folded the castle secret star slot into every range, so C Rank could pop with basement stars still missing. The collected star now counts only when it is new and belongs to the range, the courses in a range are summed directly, and the 100 coin star is masked out of the six main star check.

**[7d2718e3](https://github.com/quarrel07/Ghostship/commit/7d2718e3) Count a coin's full value toward the D Rank achievement**

The all-coins check ran before the coin was added to Mario's total and assumed a value of one, so a level whose last coin is a red or blue coin could never reach its limit.

**[3a06dc96](https://github.com/quarrel07/Ghostship/commit/3a06dc96) Keep achievement unlocks when the game is quit before the next save**

Progress only reached the save file on the next game save, so unlocks earned between saves were lost on quit; the ending achievements never get a save after they pop, so they were always lost. On unlock, the achievement block of the existing save file is rewritten in place, leaving unsaved game progress alone (Continue, don't save still works as before).

Tested on macOS (arm64) against develop with a save holding 27 of 28 basement stars and all castle stars: on develop, collecting a Bob-omb Battlefield star popped C Rank, an unlock followed by "Continue, don't save" and quitting was gone on reload, and reaching 146 coins with a red coin as the last pickup did not pop D Rank. With this branch, C Rank does not pop, the unlocks are still there after quitting without saving, and D Rank pops on the red coin.
