### PR TITLE
Add new enhancement toggle to straighten the buttons inside the file select sub-menus

### DIFF
--- a/src/menu/file_select.c
+++ b/src/menu/file_select.c
@@ -1,3 +1,4 @@
+#include <libultraship.h>
 #include <libultra/types.h>
 #include <libultra/gbi.h>
 
@@ -490,6 +491,12 @@ void bhv_menu_button_zoom_out(struct Object *button) {
 void bhv_menu_button_init(void) {
     gCurrentObject->oMenuButtonOrigPosX = gCurrentObject->oParentRelativePosX;
     gCurrentObject->oMenuButtonOrigPosY = gCurrentObject->oParentRelativePosY;
+
+    // spawn_object_rel_with_rot passes the z offset in as the roll, so the buttons inside
+    // the Score/Copy/Erase/Sound screens (z offset -100) sit rolled by about half a degree.
+    if (CVarGetInteger("gEnhancements.FixFileSelectButtonTilt", 0) == 1) {
+        gCurrentObject->oFaceAngleRoll = 0;
+    }
 }
 
 /**

--- a/src/port/ui/GhostshipMenuEnhancements.cpp
+++ b/src/port/ui/GhostshipMenuEnhancements.cpp
@@ -224,6 +224,13 @@ void GhostshipMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Fixes the Koopa race music on Bob-omb Battlefield and Tiny-Huge Island."));
 
+    AddWidget(path, "Fix File Select Button Tilt", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FixFileSelectButtonTilt"))
+        .Options(CheckboxOptions().Tooltip(
+            "Straightens the file and menu buttons inside the Score, Copy, Erase, and Sound screens of the file select. "
+            "The original game rolls them by about half a degree. "
+            "(Takes effect the next time one of those screens is opened.)"));
+
     path = { "Enhancements", "Modes", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 1);
     path.column = SECTION_COLUMN_1;


### PR DESCRIPTION
Addresses #242.

The buttons inside the Score, Copy, Erase, and Sound screens of the file select are spawned with a z offset of -100, and spawn_object_rel_with_rot passes that offset in as the roll angle (the decomp flags it as a Nintendo typo), so every one of them sits rolled by about half a degree. The main Select File buttons use a z offset of 0, which is why they look straight. On the N64 that roll is under a pixel across a button at 320x240, so it mostly rounds away; at higher resolutions it shows as a visible tilt, most clearly on the Sound Select screen.

This adds "Fix File Select Button Tilt" under Enhancements > Fixes, off by default. When on, bhv_menu_button_init zeroes the roll as each menu button spawns. Nothing changes with the toggle off.

**Before (toggle off):**
<img width="864" height="455" alt="Before" src="https://github.com/user-attachments/assets/2f113663-fe42-470a-a18b-9666a6e18aef" />


**After (toggle on after exiting and returning to the menu):**
<img width="864" height="455" alt="After" src="https://github.com/user-attachments/assets/85ed2ab4-6af7-47a4-a619-13a1db40cd7d" />


Tested on macOS (arm64): with the toggle off the Score and Sound Select buttons show the same tilt as the original in an emulator; with it on, they sit straight. The toggle applies the next time a sub-menu is opened.
