### PR TITLE
Fix the Sound Select choice resetting to Stereo on every launch

### DIFF
--- a/src/port/data/SaveConversion.h
+++ b/src/port/data/SaveConversion.h
@@ -250,7 +250,9 @@ inline void LoadMainMenuSaveDataV1(const json& j, MainMenuSaveData& menu) {
 
 inline void from_json(const json& j, MainMenuSaveData& menu) {
     uint32_t version = GetSafeEntry<uint32_t>(j, "version");
-    if(version == 1) {
+    // global.json is written with SAVE_FILE_VERSION, which moved to 2 with the achievement
+    // migration, but only 1 was accepted here, so sound mode and coin score ages never loaded back.
+    if (version == SAVE_FILE_VERSION_LEGACY || version == SAVE_FILE_VERSION) {
         LoadMainMenuSaveDataV1(j, menu);
     }
 }


### PR DESCRIPTION
The main menu save data (global.json) is written with the current save file version, which moved from 1 to 2 with the achievement save migration in June, but the loader only accepted version 1. Since then the file has been ignored on every launch, so the sound mode picked in Sound Select (and the coin score ages) reset each time. 3.0.0 has this.

This accepts both versions in the loader; the fields are unchanged between them.

Tested on macOS (arm64): on develop, picking Headset in Sound Select, quitting, and relaunching shows Stereo selected again; with this branch Headset is still selected after the relaunch.
