### PR TITLE
Add new enhancement toggle to stop Heave-Hos sinking through the floor when water drains

### DIFF
--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -1,3 +1,4 @@
+#include <libultraship.h>
 #include <libultra/types.h>
 #include "port/events/list/PlayerEvent.h"
 
@@ -1351,7 +1352,11 @@ void cur_obj_move_y(f32 gravity, f32 bounciness, f32 buoyancy) {
         if (o->oPosY < waterLevel) {
             cur_obj_move_update_underwater_flags();
         } else {
-            if (o->oPosY < o->oFloorHeight) {
+            // A buoyant object above the surface is placed onto it, even when the surface has
+            // dropped below the object's floor, which drags it through that floor (Wet-Dry World
+            // Heave-Hos while the water drains). With the fix on, land it on the floor instead.
+            if (o->oPosY < o->oFloorHeight ||
+                (waterLevel < o->oFloorHeight && CVarGetInteger("gEnhancements.FixHeaveHoSinkingThroughFloor", 0) == 1)) {
                 o->oPosY = o->oFloorHeight;
                 o->oMoveFlags &= ~OBJ_MOVE_MASK_IN_WATER;
             } else {

--- a/src/port/ui/GhostshipMenuEnhancements.cpp
+++ b/src/port/ui/GhostshipMenuEnhancements.cpp
@@ -224,6 +224,12 @@ void GhostshipMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Fixes the Koopa race music on Bob-omb Battlefield and Tiny-Huge Island."));
 
+    AddWidget(path, "Fix Heave-Hos Sinking Through Floor", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FixHeaveHoSinkingThroughFloor"))
+        .Options(CheckboxOptions().Tooltip(
+            "Stops Wet-Dry World Heave-Hos from sinking through the floor when water drains past it. "
+            "(Takes effect immediately.)"));
+
     path = { "Enhancements", "Modes", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", path.sidebarName, 1);
     path.column = SECTION_COLUMN_1;


### PR DESCRIPTION
Addresses #208.

A Heave-Ho waiting underwater is held at its home spot every frame. When the water drains past its ledge, the game treats it as floating and places it on the surface, which is now below its floor, so it rides the water down through the ground. This is the original game's behavior; it only happens if Mario is close by during the drain, which Disable Draw Distance makes true from anywhere in the course.

This adds "Fix Heave-Hos Sinking Through Floor" under Enhancements > Fixes, off by default. When on, an object about to be placed on a surface below its floor lands on the floor instead. Of the places where water levels move, Wet-Dry World is the only one with enemies floating on said water, so in practice this only affects its three Heave-Hos.

**Toggle off:**
<img width="1728" height="1117" alt="Toggle Off" src="https://github.com/user-attachments/assets/9dd7458e-c09b-435d-8fea-104319b13556" />

**Toggle on:**
<img width="1728" height="1117" alt="Toggle On" src="https://github.com/user-attachments/assets/f8970738-aecd-45ce-8923-03ba6d6e282b" />


Tested on macOS (arm64): draining the water while standing at the lowest Heave-Ho, it sinks under its ledge with the toggle off and stays on the ledge with it on.
